### PR TITLE
fix unused variable warning in member_function_ptr

### DIFF
--- a/include/boost/phoenix/bind/detail/member_function_ptr.hpp
+++ b/include/boost/phoenix/bind/detail/member_function_ptr.hpp
@@ -39,7 +39,7 @@ namespace boost { namespace phoenix { namespace detail
         }
 
         template <int M, typename RhsRT, typename RhsFP>
-        bool operator==(member_function_ptr<M, RhsRT, RhsFP> const & rhs) const
+        bool operator==(member_function_ptr<M, RhsRT, RhsFP> const &) const
         {
             return false;
         }


### PR DESCRIPTION
With clang, a warning is emitted because 'rhs' is not used.
