### PR TITLE
Bugfix/basic expr

### DIFF
--- a/include/boost/phoenix/core/domain.hpp
+++ b/include/boost/phoenix/core/domain.hpp
@@ -25,7 +25,7 @@ namespace boost { namespace phoenix
         : proto::switch_<phoenix_generator>
     {
 
-      BOOST_PROTO_USE_BASIC_EXPR()
+        BOOST_PROTO_USE_BASIC_EXPR()
 
         template<typename Tag>
         struct case_


### PR DESCRIPTION
Phoenix terminals use proto::basic_expr but operators use proto::expr since phoenix implements the operators directly. This tells proto to use proto:basic_expr when building the syntax tree for consistency.

A little more background information can be found on the mailing list: http://boost.2283326.n4.nabble.com/Phoenix-and-proto-basic-expr-td4661267.html
