### PR TITLE
Add the missing modulo assign operator in the using list

### DIFF
--- a/include/boost/phoenix/operator/arithmetic.hpp
+++ b/include/boost/phoenix/operator/arithmetic.hpp
@@ -42,6 +42,7 @@ namespace boost { namespace phoenix
     using proto::exprns_::operator-=;
     using proto::exprns_::operator*=;
     using proto::exprns_::operator/=;
+    using proto::exprns_::operator%=;
     using proto::exprns_::operator+;
     using proto::exprns_::operator-;
     using proto::exprns_::operator*;


### PR DESCRIPTION
This pull request just adds the missing modulo assign operator which was present in phoenix V2 but vanished in V3.
