### PR TITLE
Suppress unused local typedef warning in let.

### DIFF
--- a/include/boost/phoenix/scope/let.hpp
+++ b/include/boost/phoenix/scope/let.hpp
@@ -177,7 +177,7 @@ namespace boost { namespace phoenix
             , Map
             , Expr
            >::type let_type;
-           typedef is_value<let_type> is_val;
+           //typedef is_value<let_type> is_val;
 
            let_type let_exp = expression::let_<Locals, Map, Expr>::make(locals, Map(), expr);
            //if(is_val::value) //This seems always to be true


### PR DESCRIPTION
I think, this is trivial and can be merged into master (for 1.58.0).