### PR TITLE
Proviede accessibility to thrown exception for catch_ stmt.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -91,6 +91,14 @@ CHANGELOG
   New test files:
     lazy_compose_tests.cpp lazy_fold_tests.cpp lazy_scan_tests.cpp
 
+- Feature enhancements #5604 Sequenced statements of a catch_ statement is
+  now able to handle thrown exception via local variables.
+
+  Modified files:
+    boost/phoenix/statement/try_catch.hpp
+  Modified test files:
+    exceptions.cpp
+
 - V3.2.0 - in Boost 1.58.0
 
 - patch for #10927 in test/stdlib/cmath.cpp

--- a/doc/html/index.html
+++ b/doc/html/index.html
@@ -347,7 +347,7 @@
   </h3>
 </div>
 <table xmlns:rev="http://www.cs.rpi.edu/~gregod/boost/tools/doc/revision" width="100%"><tr>
-<td align="left"><p><small>Last revised: March 12, 2015 at 10:37:18 GMT</small></p></td>
+<td align="left"><p><small>Last revised: March 26, 2015 at 13:50:34 GMT</small></p></td>
 <td align="right"><div class="copyright-footer"></div></td>
 </tr></table>
 <hr>

--- a/doc/html/phoenix/modules/statement/try__catch__statement.html
+++ b/doc/html/phoenix/modules/statement/try__catch__statement.html
@@ -40,6 +40,10 @@
 <span class="special">[</span>
     <span class="identifier">sequenced_statements</span>
 <span class="special">]</span>
+<span class="special">.</span><span class="identifier">catch_</span><span class="special">&lt;</span><span class="identifier">another_exception_type</span><span class="special">&gt;(</span><span class="identifier">local</span><span class="special">-</span><span class="identifier">id</span><span class="special">)</span>
+<span class="special">[</span>
+    <span class="identifier">sequenced_statements</span>
+<span class="special">]</span>
 <span class="special">...</span>
 <span class="special">.</span><span class="identifier">catch_all</span>
 <span class="special">[</span>
@@ -49,6 +53,11 @@
 <p>
           Note the usual underscore after try and catch, and the extra parentheses
           required after the catch.
+        </p>
+<p>
+          The second form of catch statement can refer thrown exception using specified
+          local-id, which is <a class="link" href="../scope/local_variables.html" title="Local Variables">Local
+          Variables</a>, in sequenced_statements.
         </p>
 <p>
           Example: The following code calls the (lazy) function <code class="computeroutput"><span class="identifier">f</span></code>
@@ -63,9 +72,9 @@
 <span class="special">[</span>
     <span class="identifier">cout</span> <span class="special">&lt;&lt;</span> <span class="identifier">val</span><span class="special">(</span><span class="string">"caught runtime error or derived\n"</span><span class="special">)</span>
 <span class="special">]</span>
-<span class="special">.</span><span class="identifier">catch_</span><span class="special">&lt;</span><span class="identifier">exception</span><span class="special">&gt;()</span>
+<span class="special">.</span><span class="identifier">catch_</span><span class="special">&lt;</span><span class="identifier">exception</span><span class="special">&gt;(</span><span class="identifier">e_</span><span class="special">)</span>
 <span class="special">[</span>
-    <span class="identifier">cout</span> <span class="special">&lt;&lt;</span> <span class="identifier">val</span><span class="special">(</span><span class="string">"caught exception or derived\n"</span><span class="special">)</span>
+    <span class="identifier">cout</span> <span class="special">&lt;&lt;</span> <span class="identifier">val</span><span class="special">(</span><span class="string">"caught exception or derived: "</span><span class="special">)</span> <span class="special">&lt;&lt;</span> <span class="identifier">bind</span><span class="special">(&amp;</span><span class="identifier">exception</span><span class="special">::</span><span class="identifier">what</span><span class="special">,</span> <span class="identifier">e_</span><span class="special">)</span> <span class="special">&lt;&lt;</span> <span class="identifier">val</span><span class="special">(</span><span class="string">"\n"</span><span class="special">)</span>
 <span class="special">]</span>
 <span class="special">.</span><span class="identifier">catch_all</span>
 <span class="special">[</span>

--- a/doc/modules/statement.qbk
+++ b/doc/modules/statement.qbk
@@ -289,6 +289,10 @@ The syntax is:
     [
         sequenced_statements
     ]
+    .catch_<another_exception_type>(local-id)
+    [
+        sequenced_statements
+    ]
     ...
     .catch_all
     [
@@ -297,6 +301,9 @@ The syntax is:
 
 Note the usual underscore after try and catch, and the extra parentheses required
 after the catch.
+
+The second form of catch statement can refer thrown exception using specified
+local-id, which is __phoenix_local_variable__, in sequenced_statements.
 
 [/note `do_` is one example of a customized actor. See [link phoenix.advanced.extending.extending_actors Extending Actors] for more details]
 
@@ -311,9 +318,9 @@ prints messages about different exception types it catches.
     [
         cout << val("caught runtime error or derived\n")
     ]
-    .catch_<exception>()
+    .catch_<exception>(e_)
     [
-        cout << val("caught exception or derived\n")
+        cout << val("caught exception or derived: ") << bind(&exception::what, e_) << val("\n")
     ]
     .catch_all
     [

--- a/doc/phoenix3.qbk
+++ b/doc/phoenix3.qbk
@@ -61,6 +61,7 @@
 [def __boost_result_of__ [@http://www.boost.org/doc/libs/release/libs/utility/utility.htm#result_of Boost.Result Of]]
 [def __phoenix_starter_kit__ [link phoenix.starter_kit Starter Kit]]
 [def __phoenix_modules__ [link phoenix.modules Modules]]
+[def __phoenix_local_variable__ [link phoenix.modules.scope.local_variables Local Variables]]
 [def __phoenix_actions__ [link phoenix.inside.actions Actions]]
 [def __phoenix_custom_terminals__ [link phoenix.inside.custom_terminals Custom Terminals]]
 [def __phoenix_placeholder_unification__ [link phoenix.inside.placeholder_unification Placeholder Unification]]

--- a/include/boost/phoenix/statement/detail/catch_push_back.hpp
+++ b/include/boost/phoenix/statement/detail/catch_push_back.hpp
@@ -54,8 +54,48 @@
 #endif
 
 #else
+        template <typename TryCatch, typename Exception, typename Capture, typename Expr>
+        struct catch_push_back<TryCatch, Exception, Capture, Expr, BOOST_PHOENIX_ITERATION>
+        {
+            typedef
+                typename proto::result_of::make_expr<
+                    phoenix::tag::catch_
+                  , proto::basic_default_domain
+                  , catch_exception<Exception>
+                  , Capture
+                  , Expr
+                >::type
+                catch_expr;
+
+            typedef phoenix::expression::try_catch<
+                BOOST_PP_REPEAT(BOOST_PHOENIX_ITERATION, BOOST_PHOENIX_CATCH_PUSH_BACK_R0, _)
+              , catch_expr> gen_type;
+            typedef typename gen_type::type type;
+
+            static type
+            make(
+                TryCatch const& try_catch
+              , Capture const& capture
+              , Expr const& catch_
+            )
+            {
+                return
+                    gen_type::make(
+                        BOOST_PP_REPEAT(
+                            BOOST_PHOENIX_ITERATION
+                          , BOOST_PHOENIX_CATCH_PUSH_BACK_R1
+                          , _
+                        )
+                      , proto::make_expr<
+                            phoenix::tag::catch_
+                          , proto::basic_default_domain
+                        >(catch_exception<Exception>(), capture, catch_)
+                    );
+            }
+        };
+
         template <typename TryCatch, typename Exception, typename Expr>
-        struct catch_push_back<TryCatch, Exception, Expr, BOOST_PHOENIX_ITERATION>
+        struct catch_push_back<TryCatch, Exception, void, Expr, BOOST_PHOENIX_ITERATION>
         {
             typedef
                 typename proto::result_of::make_expr<
@@ -91,7 +131,7 @@
                     );
             }
         };
-        
+
         template <typename TryCatch, typename Expr>
         struct catch_all_push_back<TryCatch, Expr, BOOST_PHOENIX_ITERATION>
         {

--- a/include/boost/phoenix/statement/detail/try_catch_eval.hpp
+++ b/include/boost/phoenix/statement/detail/try_catch_eval.hpp
@@ -40,10 +40,10 @@
                         BOOST_PP_CAT(A, N)                                      \
                       , 0                                                       \
                     >::type                                                     \
-                >::type::type &                                                 \
+                >::type::type &e                                                \
             )                                                                   \
             {                                                                   \
-                boost::phoenix::eval(proto::child_c<1>(BOOST_PP_CAT(a, N)), ctx);               \
+                eval_catch_body(BOOST_PP_CAT(a, N), e, ctx);                    \
             }                                                                   \
     /**/
 

--- a/include/boost/phoenix/statement/try_catch.hpp
+++ b/include/boost/phoenix/statement/try_catch.hpp
@@ -15,7 +15,10 @@
 #include <boost/phoenix/core/expression.hpp>
 #include <boost/phoenix/core/meta_grammar.hpp>
 #include <boost/phoenix/core/is_nullary.hpp>
+#include <boost/phoenix/scope/local_variable.hpp>
+#include <boost/phoenix/scope/scoped_environment.hpp>
 #include <boost/proto/functional/fusion/pop_front.hpp>
+#include <boost/core/enable_if.hpp>
 
 #ifdef _MSC_VER
 #pragma warning(push)
@@ -52,8 +55,13 @@ namespace boost { namespace phoenix
         // bring in the expression definitions
         #include <boost/phoenix/statement/detail/try_catch_expression.hpp>
 
-        template <typename A0, typename A1>
+        template <typename A0, typename A1, typename A2 = void>
         struct catch_
+            : proto::nary_expr<tag::catch_, A0, A1, A2>
+        {};
+
+        template <typename A0, typename A1>
+        struct catch_<A0, A1, void>
             : proto::binary_expr<tag::catch_, A0, A1>
         {};
         
@@ -65,10 +73,25 @@ namespace boost { namespace phoenix
 
     namespace rule
     {
-        struct catch_
-            : expression::catch_<
+        typedef
+            expression::catch_<
+                proto::terminal<catch_exception<proto::_> >
+              , local_variable
+              , meta_grammar
+            >
+        captured_catch;
+
+        typedef
+            expression::catch_<
                 proto::terminal<catch_exception<proto::_> >
               , meta_grammar
+            >
+        non_captured_catch;
+
+        struct catch_
+            : proto::or_<
+                captured_catch
+              , non_captured_catch
             >
         {};
         
@@ -110,6 +133,48 @@ namespace boost { namespace phoenix
         void operator()(Try const &, Context const &) const
         {}
 
+        template <typename Catch, typename Exception, typename Context>
+        typename enable_if<proto::matches<Catch, rule::non_captured_catch> >::type
+        eval_catch_body(Catch const &c, Exception & /*unused*/, Context const &ctx) const
+        {
+            phoenix::eval(proto::child_c<1>(c), ctx);
+        }
+
+        template <typename Catch, typename Exception, typename Context>
+        typename enable_if<proto::matches<Catch, rule::captured_catch> >::type
+        eval_catch_body(Catch const &c, Exception &e, Context const &ctx) const
+        {
+            typedef
+                typename proto::detail::uncvref<
+                    typename proto::result_of::value<
+                        typename proto::result_of::child_c<Catch, 1>::type
+                    >::type
+                >::type
+            capture_type;
+            typedef
+                typename proto::detail::uncvref<
+                    typename result_of::env<Context>::type
+                >::type
+            env_type;
+            typedef vector1<Exception &> local_type;
+            typedef detail::map_local_index_to_tuple<capture_type> map_type;
+
+            typedef
+                phoenix::scoped_environment<
+                    env_type
+                  , env_type
+                  , local_type
+                  , map_type
+                >
+            scoped_env_tpe;
+
+            local_type local = {e};
+
+            scoped_env_tpe env(phoenix::env(ctx), phoenix::env(ctx), local);
+
+            phoenix::eval(proto::child_c<2>(c), phoenix::context(env, phoenix::actions(ctx)));
+        }
+
         // bring in the operator overloads
         #include <boost/phoenix/statement/detail/try_catch_eval.hpp>
     };
@@ -135,12 +200,31 @@ namespace boost { namespace phoenix
                 >
               , proto::when<
                     phoenix::rule::catch_
-                  , proto::call<
-                        evaluator(
-                            proto::_child_c<1>
-                          , proto::_data
-                          , proto::make<proto::empty_env()>
-                        )
+                  , proto::or_<
+                        proto::when<
+                            phoenix::rule::captured_catch
+                          , proto::call<
+                                evaluator(
+                                    proto::_child_c<2>
+                                  , proto::call<
+                                        phoenix::functional::context(
+                                            proto::make<mpl::true_()>
+                                          , proto::make<detail::scope_is_nullary_actions()>
+                                        )
+                                    >
+                                  , proto::make<proto::empty_env()>
+                                )
+                            >
+                        >
+                      , proto::otherwise<
+                            proto::call<
+                                evaluator(
+                                    proto::_child_c<1>
+                                  , proto::_data
+                                  , proto::make<proto::empty_env()>
+                                )
+                            >
+                        >
                     >
                 >
               , proto::when<
@@ -181,13 +265,48 @@ namespace boost { namespace phoenix
         template <
             typename TryCatch
           , typename Exception
+          , typename Capture
           , typename Expr
           , long Arity = proto::arity_of<TryCatch>::value
         >
         struct catch_push_back;
 
+        template <typename TryCatch, typename Exception, typename Capture, typename Expr>
+        struct catch_push_back<TryCatch, Exception, Capture, Expr, 1>
+        {
+            typedef
+                typename proto::result_of::make_expr<
+                    phoenix::tag::catch_
+                  , proto::basic_default_domain
+                  , catch_exception<Exception>
+                  , Capture
+                  , Expr
+                >::type
+                catch_expr;
+
+            typedef
+                phoenix::expression::try_catch<
+                    TryCatch
+                  , catch_expr
+                >
+                gen_type;
+            typedef typename gen_type::type type;
+
+            static type make(TryCatch const & try_catch, Capture const & capture, Expr const & catch_)
+            {
+                return
+                    gen_type::make(
+                        try_catch
+                      , proto::make_expr<
+                            phoenix::tag::catch_
+                          , proto::basic_default_domain
+                        >(catch_exception<Exception>(), capture, catch_)
+                    );
+            }
+        };
+
         template <typename TryCatch, typename Exception, typename Expr>
-        struct catch_push_back<TryCatch, Exception, Expr, 1>
+        struct catch_push_back<TryCatch, Exception, void, Expr, 1>
         {
             typedef
                 typename proto::result_of::make_expr<
@@ -271,8 +390,38 @@ namespace boost { namespace phoenix
         >
     {};
 
-    template <typename TryCatch, typename Exception>
+    template <typename TryCatch, typename Exception, typename Capture = void>
     struct catch_gen
+    {
+        catch_gen(TryCatch const& try_catch_, Capture const& capture)
+            : try_catch(try_catch_)
+            , capture(capture) {}
+
+        template <typename Expr>
+        typename boost::disable_if<
+            proto::matches<
+                typename proto::result_of::child_c<
+                    TryCatch
+                  , proto::arity_of<TryCatch>::value - 1
+                >::type
+              , rule::catch_all
+            >
+          , typename detail::catch_push_back<TryCatch, Exception, Capture, Expr>::type
+        >::type
+        operator[](Expr const& expr) const
+        {
+            return
+                detail::catch_push_back<TryCatch, Exception, Capture, Expr>::make(
+                    try_catch, capture, expr
+                );
+        }
+
+        TryCatch const & try_catch;
+        Capture const & capture;
+    };
+
+    template <typename TryCatch, typename Exception>
+    struct catch_gen<TryCatch, Exception, void>
     {
         catch_gen(TryCatch const& try_catch_) : try_catch(try_catch_) {}
 
@@ -285,12 +434,12 @@ namespace boost { namespace phoenix
                 >::type
               , rule::catch_all
             >
-          , typename detail::catch_push_back<TryCatch, Exception, Expr>::type
+          , typename detail::catch_push_back<TryCatch, Exception, void, Expr>::type
         >::type
         operator[](Expr const& expr) const
         {
             return
-                detail::catch_push_back<TryCatch, Exception, Expr>::make(
+                detail::catch_push_back<TryCatch, Exception, void, Expr>::make(
                     try_catch, expr
                 );
         }
@@ -347,6 +496,13 @@ namespace boost { namespace phoenix
         catch_() const
         {
             return catch_gen<that_type, Exception>(*this);
+        }
+
+        template <typename Exception, typename Capture>
+        catch_gen<that_type, Exception, Capture> const
+        catch_(Capture const &expr) const
+        {
+            return catch_gen<that_type, Exception, Capture>(*this, expr);
         }
 
         catch_all_gen<that_type> const catch_all;


### PR DESCRIPTION
Hi @fletchjp and @djowel !

This PR contains a feature enhancement which provides accessibility to thrown exception for catch_ stmt.
e.g.
```c++
try_
[
    throw_(runtime_error("error"))
]
.catch_<exception>(local_names::e_) // Note, accepts local variables only.
[
    std::cout << bind(&exception::what, local_names::e_) << std::endl;
]
```

If OK to merge, I will push one more patch which just regenerating preprocessed files: 401968b7622fd6f672ce6fa4db7a36a359ec733c.

see also: [#5604](https://svn.boost.org/trac/boost/ticket/5604)