### PR TITLE
Fix TRAC 11226 by partially reverting b959ed0c33ef28ec978689a8b1235661fc...

### DIFF
--- a/include/boost/phoenix/scope/let.hpp
+++ b/include/boost/phoenix/scope/let.hpp
@@ -119,7 +119,7 @@ namespace boost { namespace phoenix
 
             locals_type locals = initialize_locals(proto::value(vars_), ctx);
 
-            typedef typename result<let_eval(Vars const&, Map const&, Expr const &, Context const &)>::type result_type;
+            //typedef typename result<let_eval(Vars const&, Map const&, Expr const &, Context const &)>::type result_type;
 
             scoped_environment<
                 env_type
@@ -136,7 +136,7 @@ namespace boost { namespace phoenix
             //strm << vsize << std::endl;
             //int size = strm.str().length();
             //BOOST_ASSERT(size >= 0);
-            result_type r = eval(expr, phoenix::context(env, phoenix::actions(ctx)));
+            return eval(expr, phoenix::context(env, phoenix::actions(ctx)));
             // typedef is_value<result_type> is_val;
             //if(is_val::value) This seems always to be true
             //{
@@ -144,7 +144,7 @@ namespace boost { namespace phoenix
             // }
             //if (is_val(r) ) std::cout << "let returns val" << std::endl;
             //std::cout << "result is " << r << std::endl;
-            return r;
+            //return r;
         }
     };
 

--- a/test/scope/let_tests.cpp
+++ b/test/scope/let_tests.cpp
@@ -18,6 +18,7 @@
 #include <boost/phoenix/function.hpp>
 #include <boost/phoenix/fusion.hpp>
 #include <boost/phoenix/scope.hpp>
+#include <boost/phoenix/object/construct.hpp>
 
 #include <typeinfo>
 
@@ -172,6 +173,15 @@ main()
         int i = 1;
         int& j = let(_a = arg1)[_a](i);
         BOOST_TEST(&i == &j);
+    }
+
+    {
+        // show that a let with a void result can compile
+        using boost::phoenix::construct;
+
+        let(_a = 1)[             // need at least one expression here
+            construct<void>()    // produce a void result
+            ]();
     }
 
     {


### PR DESCRIPTION
Restores the direct return of the let expression's value in place of the assignment-then-return code, to fix compile errors when the let expression's value is void.  Also, adds a test to ensure such expressions will compile properly in the future.