### PR TITLE
Fix compilation for MSVC 10

### DIFF
--- a/include/boost/phoenix/stl/algorithm/detail/std_unordered_set_or_map_fwd.hpp
+++ b/include/boost/phoenix/stl/algorithm/detail/std_unordered_set_or_map_fwd.hpp
@@ -20,8 +20,9 @@
 #include <boost/phoenix/config.hpp>
 
 #ifdef BOOST_PHOENIX_HAS_UNORDERED_SET_AND_MAP
-#ifdef BOOST_PHOENIX_USING_LIBCPP
-// Advance declaration not working for libc++
+#if defined(BOOST_PHOENIX_USING_LIBCPP) \
+  || (defined(BOOST_DINKUMWARE_STDLIB) && (BOOST_DINKUMWARE_STDLIB < 540))
+// Advance declaration not working for libc++ and MSVC 10
 #include <unordered_set>
 #include <unordered_map>
 #else


### PR DESCRIPTION
With the Dinkumware standard library shipped with Visual C++ 10, the unordered containers are defined in namespace std::tr1 and brought into namespace std via a using-declaration. This leads to compile errors when re-declaring the classes in namespace std.

The errors are visible here:
http://www.boost.org/development/tests/develop/developer/output/teeks99-08c-win2012R2-64on64-boost-bin-v2-libs-phoenix-test-querying_find-test-msvc-10-0-dbg-adrs-mdl-64-thrd-mlt.html