### PR TITLE
Fix missing specialization.

### DIFF
--- a/include/boost/phoenix/core/actor.hpp
+++ b/include/boost/phoenix/core/actor.hpp
@@ -114,6 +114,15 @@ namespace boost { namespace phoenix
                 ;
             };
 
+            template <typename Expr, typename State, typename Data>
+            struct impl<Expr, State, Data, detail::index_sequence<> >
+                : proto::when<
+                    proto::terminal<proto::_>
+                  , do_assign(proto::_, proto::_state)
+                >::template impl<Expr, State, Data>
+            {
+            };
+
             template <typename Expr, typename State, typename Data
                     , std::size_t... Indices>
             struct impl<Expr, State, Data, detail::index_sequence<Indices...> >


### PR DESCRIPTION
see [Flast-FreeBSD10-clang-3.7.0~gnu++11 - phoenix - bug4853 / clang-linux-3.7.0](http://www.boost.org/development/tests/develop/developer/output/Flast-FreeBSD10-clang-3-7-0~gnu++11-boost-bin-v2-libs-phoenix-test-bug4853-test-clang-linux-3-7-0-debug.html).

This doesn't affect 1.62.0 (upcoming) release due to regression of variadics.