### PR TITLE
Fix result type deduction failure.

### DIFF
--- a/include/boost/phoenix/stl/algorithm/querying.hpp
+++ b/include/boost/phoenix/stl/algorithm/querying.hpp
@@ -40,7 +40,7 @@ namespace boost { namespace phoenix {
             struct result;
 
             template <typename This, class R, class T>
-            struct result<This(R&, T const&)>
+            struct result<This(R&, T&)>
                 : range_iterator<R>
             {};
 
@@ -202,7 +202,7 @@ namespace boost { namespace phoenix {
             struct result;
 
             template <typename This, class R, class T>
-            struct result<This(R&, T const&)>
+            struct result<This(R&, T&)>
                 : range_difference<R>
             {};
 
@@ -314,12 +314,12 @@ namespace boost { namespace phoenix {
             struct result;
 
             template <typename This, class R, class T>
-            struct result<This(R&, T const&)>
+            struct result<This(R&, T&)>
                 : range_iterator<R>
             {};
 
             template <typename This, class R, class T, class C>
-            struct result<This(R&, T const&, C)>
+            struct result<This(R&, T&, C)>
                 : range_iterator<R>
             {};
 
@@ -358,12 +358,12 @@ namespace boost { namespace phoenix {
             struct result;
 
             template <typename This, class R, class T>
-            struct result<This(R&, T const&)>
+            struct result<This(R&, T&)>
                 : range_iterator<R>
             {};
 
             template <typename This, class R, class T, class C>
-            struct result<This(R&, T const&, C)>
+            struct result<This(R&, T&, C)>
                 : range_iterator<R>
             {};
 
@@ -414,12 +414,12 @@ namespace boost { namespace phoenix {
             struct result;
 
             template <typename This, class R, class T>
-            struct result<This(R&, T const&)>
+            struct result<This(R&, T&)>
                 : result_of::equal_range<R,T>
             {};
 
             template <typename This, class R, class T, class C>
-            struct result<This(R&, T const&, C)>
+            struct result<This(R&, T&, C)>
                 : result_of::equal_range<R,T, C>
             {};
 

--- a/include/boost/phoenix/stl/algorithm/transformation.hpp
+++ b/include/boost/phoenix/stl/algorithm/transformation.hpp
@@ -158,7 +158,7 @@ namespace boost { namespace phoenix { namespace impl
         struct result;
 
         template<typename This, class R, class O, class T, class T2>
-        struct result<This(R&, O, T const&, T2 const&)>
+        struct result<This(R&, O, T&, T2&)>
             : detail::decay_array<O>
         {};
 
@@ -176,7 +176,7 @@ namespace boost { namespace phoenix { namespace impl
         struct result;
 
         template<typename This, class R, class O, class P, class T>
-        struct result<This(R&, O, P, T const&)>
+        struct result<This(R&, O, P, T&)>
             : detail::decay_array<O>
         {};
 
@@ -238,7 +238,7 @@ namespace boost { namespace phoenix { namespace impl
         struct result;
 
         template<typename This, class R, class T>
-        struct result<This(R&, T const&)>
+        struct result<This(R&, T&)>
             : range_iterator<R>
         {
         };

--- a/include/boost/phoenix/stl/container/container.hpp
+++ b/include/boost/phoenix/stl/container/container.hpp
@@ -94,7 +94,7 @@ namespace boost { namespace phoenix
               , typename C
               , typename Arg1
             >
-            struct result<This(C&, Arg1 const &)>
+            struct result<This(C&, Arg1&)>
             {
                 typedef typename add_reference<C>::type type;
             };


### PR DESCRIPTION
see [igaztanaga-develop-gcc-4.6c++11 - phoenix - bug7624 / gcc-mngw-4.6c+](http://www.boost.org/development/tests/develop/developer/output/igaztanaga-develop-gcc-4-6c++11-boost-bin-v2-libs-phoenix-test-bug7624-test-gcc-mngw-4-6c+-dbg-dbg-symbl-off.html)

Tested on:

- gcc 6.1.1 (fedora rawhide) gnu++98 / gnu++11 / gnu++14 / gnu++1z
- clang 3.8.1 (fedora rawhide) gnu++98 / gnu++11 / gnu++14 / gnu++1z
- gcc 4.6.3 (fedora 16) gnu++98 / gnu++0x
