### PR TITLE
Make is_std_unordered_* available at any time.

### DIFF
--- a/include/boost/phoenix/stl/algorithm/detail/has_find.hpp
+++ b/include/boost/phoenix/stl/algorithm/detail/has_find.hpp
@@ -22,6 +22,7 @@
 #include "./is_std_set.hpp"
 #include "./is_std_hash_map.hpp"
 #include "./is_std_hash_set.hpp"
+#include "./is_unordered_set_or_map.hpp"
 
 namespace boost
 {
@@ -41,12 +42,15 @@ namespace boost
               , is_std_hash_set<T>
               , is_std_hash_multiset<T>
           >
+          , boost::mpl::or_<
+                is_std_unordered_map<T>
+              , is_std_unordered_multimap<T>
+              , is_std_unordered_set<T>
+              , is_std_unordered_multiset<T>
+            >
         >
     {
     };
 }
-
-// Bring in unordered_set and unordered_map stuff.
-#include "./is_unordered_set_or_map.hpp"
 
 #endif

--- a/include/boost/phoenix/stl/algorithm/detail/is_unordered_set_or_map.hpp
+++ b/include/boost/phoenix/stl/algorithm/detail/is_unordered_set_or_map.hpp
@@ -23,8 +23,6 @@
 #include <boost/mpl/bool.hpp>
 #include "./std_unordered_set_or_map_fwd.hpp"
 
-#ifdef BOOST_PHOENIX_HAS_UNORDERED_SET_AND_MAP
-
 namespace boost
 {
     template<class T>
@@ -46,6 +44,8 @@ namespace boost
     struct is_std_unordered_multimap
         : boost::mpl::false_
     {};
+
+#ifdef BOOST_PHOENIX_HAS_UNORDERED_SET_AND_MAP
 
     template<
         class Kty
@@ -89,56 +89,7 @@ namespace boost
         : boost::mpl::true_
     {};
 
-    template<
-        class Kty
-      , class Hash
-      , class Cmp
-      , class Alloc
-    >
-    struct has_find< std::unordered_set<Kty,Hash,Cmp,Alloc> >
-        : boost::mpl::true_
-    {
-    };
-
-    template<
-        class Kty
-      , class Hash
-      , class Cmp
-      , class Alloc
-    >
-    struct has_find< std::unordered_multiset<Kty,Hash,Cmp,Alloc> >
-        : boost::mpl::true_
-    {
-    };
-    
-    template<
-        class Kty
-      , class Ty
-      , class Hash
-      , class Cmp
-      , class Alloc
-    >
-    struct has_find< std::unordered_map<Kty,Ty,Hash,Cmp,Alloc> >
-        : boost::mpl::true_
-    {
-    };
- 
-    template<
-        class Kty
-      , class Ty
-      , class Hash
-      , class Cmp
-      , class Alloc
-    >
-    struct has_find< std::unordered_multimap<Kty,Ty,Hash,Cmp,Alloc> >
-        : boost::mpl::true_
-    {
-    };
-  
-   
-}
-
 #endif
-
+} // namespace boost
 
 #endif


### PR DESCRIPTION
tested on fedora rawhide (gcc 6.1.1/clang 3.8.0)