### PR TITLE
Don't overload with return type.

### DIFF
--- a/include/boost/phoenix/stl/container/container.hpp
+++ b/include/boost/phoenix/stl/container/container.hpp
@@ -349,39 +349,19 @@ namespace boost { namespace phoenix
             {};
 
             template <typename C, typename Arg1>
-            typename stl_impl::disable_if_is_void<
-                typename result_of::erase<C, Arg1>::type
-            >::type
+            typename result_of::erase<C, Arg1>::type
             operator()(C& c, Arg1 arg1) const
             {
-                return c.erase(arg1);
-            }
-
-            template <typename C, typename Arg1>
-            typename stl_impl::enable_if_is_void<
-                typename result_of::erase<C, Arg1>::type
-            >::type
-            operator()(C& c, Arg1 arg1) const
-            {
-                c.erase(arg1);
+                typedef typename result_of::erase<C, Arg1>::type result_type;
+                return static_cast<result_type>(c.erase(arg1));
             }
 
             template <typename C, typename Arg1, typename Arg2>
-            typename stl_impl::disable_if_is_void<
-                typename result_of::erase<C, Arg1, Arg2>::type
-            >::type
+            typename result_of::erase<C, Arg1, Arg2>::type
             operator()(C& c, Arg1 arg1, Arg2 arg2) const
             {
-                return c.erase(arg1, arg2);
-            }
-
-            template <typename C, typename Arg1, typename Arg2>
-            typename stl_impl::enable_if_is_void<
-                typename result_of::erase<C, Arg1, Arg2>::type
-            >::type
-            operator()(C& c, Arg1 arg1, Arg2 arg2) const
-            {
-                c.erase(arg1, arg2);
+                typedef typename result_of::erase<C, Arg1, Arg2>::type result_type;
+                return static_cast<result_type>(c.erase(arg1, arg2));
             }
         };
 
@@ -534,41 +514,19 @@ namespace boost { namespace phoenix
             }
 
             template <typename C, typename Arg1, typename Arg2>
-            typename stl_impl::disable_if_is_void<
-                typename result<insert(C&, Arg1, Arg2)>::type
-            >::type
+            typename result<insert(C&, Arg1, Arg2)>::type
             operator()(C& c, Arg1 arg1, Arg2 arg2) const
             {
-                return c.insert(arg1, arg2);
-            }
-
-            template <typename C, typename Arg1, typename Arg2>
-            typename stl_impl::enable_if_is_void<
-                typename result<insert(C&, Arg1, Arg2)>::type
-            >::type
-            operator()(C& c, Arg1 arg1, Arg2 arg2) const
-            {
-                c.insert(arg1, arg2);
+                typedef typename result<insert(C&, Arg1, Arg2)>::type result_type;
+                return static_cast<result_type>(c.insert(arg1, arg2));
             }
 
             template <typename C, typename Arg1, typename Arg2, typename Arg3>
-            typename stl_impl::disable_if_is_void<
-                typename result<insert(C&, Arg1, Arg2, Arg3)>::type
-            >::type
-            operator()(
-                C& c, Arg1 arg1, Arg2 arg2, Arg3 arg3) const
+            typename result<insert(C&, Arg1, Arg2, Arg3)>::type
+            operator()(C& c, Arg1 arg1, Arg2 arg2, Arg3 arg3) const
             {
-                return c.insert(arg1, arg2, arg3);
-            }
-
-            template <typename C, typename Arg1, typename Arg2, typename Arg3>
-            typename stl_impl::enable_if_is_void<
-                typename result<insert(C&, Arg1, Arg2, Arg3)>::type
-            >::type
-            operator()(
-                C& c, Arg1 arg1, Arg2 arg2, Arg3 arg3) const
-            {
-                c.insert(arg1, arg2, arg3);
+                typedef typename result<insert(C&, Arg1, Arg2, Arg3)>::type result_type;
+                return static_cast<result_type>(c.insert(arg1, arg2, arg3));
             }
         };
 

--- a/include/boost/phoenix/stl/container/detail/container.hpp
+++ b/include/boost/phoenix/stl/container/detail/container.hpp
@@ -124,26 +124,6 @@ namespace boost { namespace phoenix { namespace stl
 
         template <typename C>
         two has_mapped_type(...);
-
-        template<typename T>
-        struct enable_if_is_void
-        {};
-
-        template<>
-        struct enable_if_is_void<void>
-        {
-            typedef void type;
-        };
-
-        template<typename T>
-        struct disable_if_is_void
-        {
-            typedef T type;
-        };
-
-        template<>
-        struct disable_if_is_void<void>
-        {};
     }
 
     template <typename C>


### PR DESCRIPTION
Some older GCC fails to overload.

tested under
- fedora rawhide gcc 6.1.1
- fedora rawhide clang 3.8.0
- fedora core 3 gcc 3.4.4
- msvc 8 / 9sp1 / 10sp1 / 11u5 / 12u5 / 14u3