### PR TITLE
Update support for standard containers.

### DIFF
--- a/doc/modules/stl.qbk
+++ b/doc/modules/stl.qbk
@@ -31,6 +31,8 @@ containers:
 * map
 * multimap
 * vector
+* set
+* multiset
 
 Indeed, should your class have member functions with the same names and
 signatures as those listed below, then it will automatically be supported. To

--- a/include/boost/phoenix/stl/container/container.hpp
+++ b/include/boost/phoenix/stl/container/container.hpp
@@ -294,24 +294,21 @@ namespace boost { namespace phoenix
                 //  returning a value. Oh well... :*
 
                 typedef
-                    boost::mpl::eval_if_c<
-                        boost::is_same<
-                            typename remove_reference<Arg1>::type
-                          , typename iterator_of<C>::type
-                        >::value
+                    boost::mpl::eval_if<
+                        is_key_type_of<C, Arg1>
+                      , size_type_of<C>
 #if defined(BOOST_MSVC)// && (BOOST_MSVC <= 1500)
                       , iterator_of<C>
 #else
                       , boost::mpl::identity<void>
 #endif
-                      , size_type_of<C>
                     >
-                map_erase_result;
+                assoc_erase_result;
 
                 typedef typename
                     boost::mpl::eval_if_c<
-                        has_mapped_type<C>::value
-                      , map_erase_result
+                        has_key_type<C>::value
+                      , assoc_erase_result
                       , iterator_of<C>
                     >::type
                 type;

--- a/include/boost/phoenix/stl/container/container.hpp
+++ b/include/boost/phoenix/stl/container/container.hpp
@@ -286,18 +286,14 @@ namespace boost { namespace phoenix
             template <typename C, typename Arg1, typename Arg2 = mpl::void_>
             struct erase
             {
-                //  BOOST_MSVC #if branch here in map_erase_result non-
-                //  standard behavior. The return type should be void but
-                //  VC7.1 prefers to return iterator_of<C>. As a result,
-                //  VC7.1 complains of error C2562:
-                //  boost::phoenix::stl::erase::operator() 'void' function
-                //  returning a value. Oh well... :*
-
+                // MSVC and libc++ always returns iterator even in C++03 mode.
                 typedef
                     boost::mpl::eval_if<
                         is_key_type_of<C, Arg1>
                       , size_type_of<C>
-#if defined(BOOST_MSVC)// && (BOOST_MSVC <= 1500)
+#if defined(BOOST_MSVC) /*&& (BOOST_MSVC <= 1500)*/ \
+ && (defined(BOOST_LIBSTDCXX11) && 40500 <= BOOST_LIBSTDCXX_VERSION) \
+ && defined(_LIBCPP_VERSION)
                       , iterator_of<C>
 #else
                       , boost::mpl::identity<void>
@@ -326,11 +322,13 @@ namespace boost { namespace phoenix
             //      1) iterator C::erase(iterator where);
             //      2) iterator C::erase(iterator first, iterator last);
             //
-            //  where A is a std::map, std::multimap, std::set, or std::multiset:
+            //  where C is a std::map, std::multimap, std::set, or std::multiset:
             //
             //      3) size_type M::erase(const Key& keyval);
-            //      4) void M::erase(iterator where);
-            //      5) void M::erase(iterator first, iterator last);
+            //      4-a) void M::erase(iterator where);
+            //      4-b) iterator M::erase(iterator where);
+            //      5-a) void M::erase(iterator first, iterator last);
+            //      5-b) iterator M::erase(iterator first, iterator last);
 
             template <typename Sig>
             struct result;

--- a/include/boost/phoenix/stl/container/container.hpp
+++ b/include/boost/phoenix/stl/container/container.hpp
@@ -33,7 +33,7 @@ namespace boost { namespace phoenix
 //      Lazy functions are provided for all of the member functions of the
 //      following containers:
 //
-//      deque - list - map - multimap - vector.
+//      deque - list - map - multimap - vector - set - multiset.
 //
 //      Indeed, should *your* class have member functions with the same names
 //      and signatures as those listed below, then it will automatically be
@@ -319,14 +319,14 @@ namespace boost { namespace phoenix
         {
             //  This mouthful can differentiate between the generic erase
             //  functions (Container == std::deque, std::list, std::vector) and
-            //  that specific to the two map-types, std::map and std::multimap.
+            //  that specific to Associative Containers.
             //
             //  where C is a std::deque, std::list, std::vector:
             //
             //      1) iterator C::erase(iterator where);
             //      2) iterator C::erase(iterator first, iterator last);
             //
-            //  where M is a std::map or std::multimap:
+            //  where A is a std::map, std::multimap, std::set, or std::multiset:
             //
             //      3) size_type M::erase(const Key& keyval);
             //      4) void M::erase(iterator where);

--- a/include/boost/phoenix/stl/container/detail/container.hpp
+++ b/include/boost/phoenix/stl/container/detail/container.hpp
@@ -12,6 +12,7 @@
 #include <boost/mpl/eval_if.hpp>
 #include <boost/type_traits/is_same.hpp>
 #include <boost/type_traits/is_const.hpp>
+#include <boost/type_traits/is_convertible.hpp>
 
 namespace boost { namespace phoenix { namespace stl
 {
@@ -110,8 +111,8 @@ namespace boost { namespace phoenix { namespace stl
 //
 //  has_mapped_type<C>
 //
-//      Given a container C, determine if it is a map or multimap
-//      by checking if it has a member type named "mapped_type".
+//      Given a container C, determine if it is a map, multimap, unordered_map,
+//      or unordered_multimap by checking if it has a member type named "mapped_type".
 //
 ///////////////////////////////////////////////////////////////////////////////
     namespace stl_impl
@@ -131,6 +132,43 @@ namespace boost { namespace phoenix { namespace stl
         : boost::mpl::bool_<
             sizeof(stl_impl::has_mapped_type<C>(0)) == sizeof(stl_impl::one)
         >
+    {};
+
+///////////////////////////////////////////////////////////////////////////////
+//
+//  has_key_type<C>
+//
+//      Given a container C, determine if it is a Associative Container
+//      by checking if it has a member type named "key_type".
+//
+///////////////////////////////////////////////////////////////////////////////
+    namespace stl_impl
+    {
+        template <typename C>
+        one has_key_type(typename C::key_type(*)());
+
+        template <typename C>
+        two has_key_type(...);
+    }
+
+    template <typename C>
+    struct has_key_type
+        : boost::mpl::bool_<
+            sizeof(stl_impl::has_key_type<C>(0)) == sizeof(stl_impl::one)
+        >
+    {};
+
+///////////////////////////////////////////////////////////////////////////////
+//
+//  is_key_type_of<C, Arg>
+//
+//      Lazy evaluation friendly predicate.
+//
+///////////////////////////////////////////////////////////////////////////////
+
+    template <typename C, typename Arg>
+    struct is_key_type_of
+        : boost::is_convertible<Arg, typename key_type_of<C>::type>
     {};
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -10,6 +10,8 @@
 # bring in rules for testing
 import testing ;
 
+import ../../config/checks/config : requires ;
+
 project
     : requirements
         <toolset>msvc:<define>_SCL_SECURE_NO_DEPRECATE
@@ -100,7 +102,15 @@ test-suite phoenix_container :
     [ run container/container_tests7a.cpp ]
     [ run container/container_tests7b.cpp ]
     [ run container/container_tests8a.cpp ]
-    [ run container/container_tests8b.cpp ]
+    [ run container/container_tests8b.cpp : : : [ requires cxx11_hdr_unordered_map ] ]
+    [ run container/container_tests9a.cpp : : : [ requires cxx11_hdr_unordered_map ] ]
+    [ run container/container_tests9b.cpp : : : [ requires cxx11_hdr_unordered_map ] ]
+    [ run container/container_tests10a.cpp : : : [ requires cxx11_hdr_unordered_map ] ]
+    [ run container/container_tests10b.cpp : : : [ requires cxx11_hdr_unordered_map ] ]
+    [ run container/container_tests11a.cpp : : : [ requires cxx11_hdr_unordered_set ] ]
+    [ run container/container_tests11b.cpp : : : [ requires cxx11_hdr_unordered_set ] ]
+    [ run container/container_tests12a.cpp : : : [ requires cxx11_hdr_unordered_set ] ]
+    [ run container/container_tests12b.cpp : : : [ requires cxx11_hdr_unordered_set ] ]
     ;
 
 test-suite phoenix_scope :

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -97,6 +97,10 @@ test-suite phoenix_container :
     [ run container/container_tests5b.cpp ] 
     [ run container/container_tests6a.cpp ] 
     [ run container/container_tests6b.cpp ] 
+    [ run container/container_tests7a.cpp ]
+    [ run container/container_tests7b.cpp ]
+    [ run container/container_tests8a.cpp ]
+    [ run container/container_tests8b.cpp ]
     ;
 
 test-suite phoenix_scope :

--- a/test/container/container_tests.hpp
+++ b/test/container/container_tests.hpp
@@ -16,6 +16,7 @@
 #include <deque>
 #include <list>
 #include <map>
+#include <set>
 #include <vector>
 #include <utility>
 
@@ -31,6 +32,8 @@ std::list<int> const build_list();
 std::map<int, int> const build_map();
 std::multimap<int, int> const build_multimap();
 std::vector<int> const build_vector();
+std::set<int> const build_set();
+std::multiset<int> const build_multiset();
 
 inline bool
 test(bool fail)
@@ -328,6 +331,27 @@ void test_map_erase(Container c)
 }
 
 template <typename Container>
+void test_set_erase(Container c)
+{
+    test_erase(c);
+    if (boost::report_errors() != 0)
+      return;
+
+    using phx::arg_names::arg1;
+    using phx::arg_names::arg2;
+    using phx::erase;
+
+    typename Container::value_type const value = *c.begin();
+    typename Container::key_type const key = value;
+    typename Container::size_type const removed =
+        erase(arg1, arg2)(c, key);
+    if (test(removed != 1)) {
+        cerr << "Failed " << typeid(Container).name() << " test_set_erase 1\n";
+        return;
+    }
+}
+
+template <typename Container>
 void test_front(Container c)
 {
     using phx::arg_names::arg1;
@@ -490,6 +514,93 @@ inline void test_multimap_insert(std::multimap<int, int> c)
     if (test(c.size() != size + const_c.size())) {
         cerr << "Failed " << typeid(Multimap).name()
        << " test_multimap_insert 3\n";
+        return;
+    }
+}
+
+inline void test_set_insert(std::set<int> c)
+{
+    using phx::arg_names::arg1;
+    using phx::arg_names::arg2;
+    using phx::arg_names::arg3;
+
+    typedef std::set<int> Set;
+
+    Set::value_type const value = *c.begin();
+    Set::iterator c_begin = c.begin();
+    // wrapper for
+    // iterator insert(iterator where, const value_type& val);
+    Set::iterator it =
+        phx::insert(arg1, arg2, arg3)(c, c_begin, value);
+
+    if (test(it != c.begin() /*|| *it != *(++it)*/)) {
+        cerr << "Failed " << typeid(Set).name() << " test_set_insert 1\n";
+        return;
+    }
+
+    // wrapper for
+    // pair<iterator, bool> insert(const value_type& val);
+    Set::value_type const value2(1400);
+    std::pair<Set::iterator, bool> result =
+      phx::insert(arg1, arg2)(c, value2);
+    if (test(!result.second)) {
+        cerr << "Failed " << typeid(Set).name() << " test_set_insert 2\n";
+        return;
+    }
+
+    // wrapper for
+    // template<class InIt>
+    // void insert(InIt first, InIt last);
+    Set const const_c = build_set();
+    Set::size_type size = c.size();
+    phx::insert(arg1, const_c.begin(), const_c.end())(c);
+    if (test(c.size() != size + const_c.size())) {
+        cerr << "Failed " << typeid(Set).name() << " test_set_insert 3\n";
+        return;
+    }
+}
+
+inline void test_multiset_insert(std::multiset<int> c)
+{
+    using phx::arg_names::arg1;
+    using phx::arg_names::arg2;
+    using phx::arg_names::arg3;
+
+    typedef std::multiset<int> Multiset;
+
+    Multiset::value_type const value = *c.begin();
+    Multiset::iterator c_begin = c.begin();
+    std::size_t old_size = c.size();
+    // wrapper for
+    // iterator insert(iterator where, const value_type& val);
+    Multiset::iterator it =
+        phx::insert(arg1, arg2, arg3)(c, c_begin, value);
+
+    if (test(*it != value || c.size() != old_size + 1)) {
+        cerr << "Failed " << typeid(Multiset).name()
+       << " test_multiset_insert 1\n";
+        return;
+    }
+
+    // wrapper for
+    // iterator insert(const value_type& val);
+    Multiset::value_type const value2(1400);
+    it = phx::insert(arg1, arg2)(c, value2);
+    if (test(it == c.end())) {
+        cerr << "Failed " << typeid(Multiset).name()
+       << " test_multiset_insert 2\n";
+        return;
+    }
+
+    // wrapper for
+    // template<class InIt>
+    // void insert(InIt first, InIt last);
+    Multiset const const_c = build_multiset();
+    Multiset::size_type size = c.size();
+    phx::insert(arg1, const_c.begin(), const_c.end())(c);
+    if (test(c.size() != size + const_c.size())) {
+        cerr << "Failed " << typeid(Multiset).name()
+       << " test_multiset_insert 3\n";
         return;
     }
 }

--- a/test/container/container_tests10a.cpp
+++ b/test/container/container_tests10a.cpp
@@ -1,0 +1,73 @@
+/*=============================================================================
+    Copyright (c) 2004 Angus Leeming
+    Copyright (c) 2017 Kohei Takahashi
+
+    Distributed under the Boost Software License, Version 1.0. (See accompanying 
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+==============================================================================*/
+#include "container_tests.hpp"
+#include <boost/static_assert.hpp>
+
+std::unordered_map<int, int> const build_unordered_map()
+{
+    typedef std::unordered_map<int, int> int_map;
+    typedef std::vector<int> int_vector;
+
+    int_map result;
+    int_vector const data = build_vector();
+    int_vector::const_iterator it = data.begin();
+    int_vector::const_iterator const end = data.end();
+    for (; it != end; ++it) {
+        int const value = *it;
+        result[value] = 100 * value;
+    }
+    return result;
+}
+
+std::unordered_multimap<int, int> const build_unordered_multimap()
+{
+    typedef std::unordered_map<int, int> int_map;
+    typedef std::unordered_multimap<int, int> int_multimap;
+    int_map const data = build_unordered_map();
+    return int_multimap(data.begin(), data.end());
+}
+
+std::vector<int> const init_vector()
+{
+    typedef std::vector<int> int_vector;
+    int const data[] = { -4, -3, -2, -1, 0 };
+    int_vector::size_type const data_size = sizeof(data) / sizeof(data[0]);
+    return int_vector(data, data + data_size);
+}
+
+std::vector<int> const build_vector()
+{
+    typedef std::vector<int> int_vector;
+    static int_vector data = init_vector();
+    int_vector::size_type const size = data.size();
+    int_vector::iterator it = data.begin();
+    int_vector::iterator const end = data.end();
+    for (; it != end; ++it)
+        *it += size;
+    return data;
+}
+
+int
+main()
+{
+    BOOST_STATIC_ASSERT((phx::stl::has_mapped_type<std::unordered_multimap<int, int> >::value));
+    BOOST_STATIC_ASSERT((phx::stl::has_key_type<std::unordered_multimap<int, int> >::value));
+
+    std::unordered_multimap<int, int> const data = build_unordered_multimap();
+    test_begin(data);
+    test_clear(data);
+    test_empty(data);
+    test_end(data);
+    test_map_erase(data);
+    test_get_allocator(data);
+    return boost::report_errors();
+}
+
+
+
+

--- a/test/container/container_tests10b.cpp
+++ b/test/container/container_tests10b.cpp
@@ -1,0 +1,74 @@
+/*=============================================================================
+    Copyright (c) 2004 Angus Leeming
+    Copyright (c) 2017 Kohei Takahashi
+
+    Distributed under the Boost Software License, Version 1.0. (See accompanying 
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+==============================================================================*/
+#include "container_tests.hpp"
+#include <boost/static_assert.hpp>
+
+std::unordered_map<int, int> const build_unordered_map()
+{
+    typedef std::unordered_map<int, int> int_map;
+    typedef std::vector<int> int_vector;
+
+    int_map result;
+    int_vector const data = build_vector();
+    int_vector::const_iterator it = data.begin();
+    int_vector::const_iterator const end = data.end();
+    for (; it != end; ++it) {
+      int const value = *it;
+      result[value] = 100 * value;
+    }
+    return result;
+}
+
+std::unordered_multimap<int, int> const build_unordered_multimap()
+{
+    typedef std::unordered_map<int, int> int_map;
+    typedef std::unordered_multimap<int, int> int_multimap;
+    int_map const data = build_unordered_map();
+    return int_multimap(data.begin(), data.end());
+}
+
+std::vector<int> const init_vector()
+{
+    typedef std::vector<int> int_vector;
+    int const data[] = { -4, -3, -2, -1, 0 };
+    int_vector::size_type const data_size = sizeof(data) / sizeof(data[0]);
+    return int_vector(data, data + data_size);
+}
+
+std::vector<int> const build_vector()
+{
+    typedef std::vector<int> int_vector;
+    static int_vector data = init_vector();
+    int_vector::size_type const size = data.size();
+    int_vector::iterator it = data.begin();
+    int_vector::iterator const end = data.end();
+    for (; it != end; ++it)
+      *it += size;
+    return data;
+}
+
+int
+main()
+{
+    BOOST_STATIC_ASSERT((phx::stl::has_mapped_type<std::unordered_multimap<int, int> >::value));
+    BOOST_STATIC_ASSERT((phx::stl::has_key_type<std::unordered_multimap<int, int> >::value));
+
+    std::unordered_multimap<int, int> const data = build_unordered_multimap();
+    test_multimap_insert(data);
+    //test_key_comp(data);
+    test_max_size(data);
+    //test_rbegin(data);
+    //test_rend(data);
+    test_size(data);
+    //test_value_comp(data);
+    return boost::report_errors();
+}
+
+
+
+

--- a/test/container/container_tests11a.cpp
+++ b/test/container/container_tests11a.cpp
@@ -1,0 +1,59 @@
+/*=============================================================================
+    Copyright (c) 2004 Angus Leeming
+    Copyright (c) 2017 Kohei Takahashi
+
+    Distributed under the Boost Software License, Version 1.0. (See accompanying 
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+==============================================================================*/
+#include "container_tests.hpp"
+#include <boost/static_assert.hpp>
+
+std::unordered_set<int> const build_unordered_set()
+{
+    typedef std::unordered_set<int> int_set;
+    typedef std::vector<int> int_vector;
+
+    int_set result;
+    int_vector const data = build_vector();
+    int_vector::const_iterator it = data.begin();
+    int_vector::const_iterator const end = data.end();
+    result.insert(it, end);
+    return result;
+}
+
+std::vector<int> const init_vector()
+{
+    typedef std::vector<int> int_vector;
+    int const data[] = { -4, -3, -2, -1, 0 };
+    int_vector::size_type const data_size = sizeof(data) / sizeof(data[0]);
+    return int_vector(data, data + data_size);
+}
+
+std::vector<int> const build_vector()
+{
+    typedef std::vector<int> int_vector;
+    static int_vector data = init_vector();
+    int_vector::size_type const size = data.size();
+    int_vector::iterator it = data.begin();
+    int_vector::iterator const end = data.end();
+    for (; it != end; ++it)
+      *it += size;
+    return data;
+}
+
+int
+main()
+{
+    BOOST_STATIC_ASSERT((!phx::stl::has_mapped_type<std::unordered_set<int> >::value));
+    BOOST_STATIC_ASSERT((phx::stl::has_key_type<std::unordered_set<int> >::value));
+
+    std::unordered_set<int> const data = build_unordered_set();
+    test_begin(data);
+    test_clear(data);
+    test_empty(data);
+    test_end(data);
+    test_set_erase(data);
+    test_get_allocator(data);
+    return boost::report_errors();
+}
+

--- a/test/container/container_tests11b.cpp
+++ b/test/container/container_tests11b.cpp
@@ -1,0 +1,60 @@
+/*=============================================================================
+    Copyright (c) 2004 Angus Leeming
+    Copyright (c) 2017 Kohei Takahashi
+
+    Distributed under the Boost Software License, Version 1.0. (See accompanying 
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+==============================================================================*/
+#include "container_tests.hpp"
+#include <boost/static_assert.hpp>
+
+std::unordered_set<int> const build_unordered_set()
+{
+    typedef std::unordered_set<int> int_set;
+    typedef std::vector<int> int_vector;
+
+    int_set result;
+    int_vector const data = build_vector();
+    int_vector::const_iterator it = data.begin();
+    int_vector::const_iterator const end = data.end();
+    result.insert(it, end);
+    return result;
+}
+
+std::vector<int> const init_vector()
+{
+    typedef std::vector<int> int_vector;
+    int const data[] = { -4, -3, -2, -1, 0 };
+    int_vector::size_type const data_size = sizeof(data) / sizeof(data[0]);
+    return int_vector(data, data + data_size);
+}
+
+std::vector<int> const build_vector()
+{
+    typedef std::vector<int> int_vector;
+    static int_vector data = init_vector();
+    int_vector::size_type const size = data.size();
+    int_vector::iterator it = data.begin();
+    int_vector::iterator const end = data.end();
+    for (; it != end; ++it)
+        *it += size;
+    return data;
+}
+
+int
+main()
+{
+    BOOST_STATIC_ASSERT((!phx::stl::has_mapped_type<std::unordered_set<int> >::value));
+    BOOST_STATIC_ASSERT((phx::stl::has_key_type<std::unordered_set<int> >::value));
+
+    std::unordered_set<int> const data = build_unordered_set();
+    test_set_insert(data);
+    //test_key_comp(data);
+    test_max_size(data);
+    //test_rbegin(data);
+    //test_rend(data);
+    test_size(data);
+    //test_value_comp(data);
+    return boost::report_errors();
+}
+

--- a/test/container/container_tests12a.cpp
+++ b/test/container/container_tests12a.cpp
@@ -1,0 +1,70 @@
+/*=============================================================================
+    Copyright (c) 2004 Angus Leeming
+    Copyright (c) 2017 Kohei Takahashi
+
+    Distributed under the Boost Software License, Version 1.0. (See accompanying 
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+==============================================================================*/
+#include "container_tests.hpp"
+#include <boost/static_assert.hpp>
+
+std::unordered_set<int> const build_unordered_set()
+{
+    typedef std::unordered_set<int> int_set;
+    typedef std::vector<int> int_vector;
+
+    int_set result;
+    int_vector const data = build_vector();
+    int_vector::const_iterator it = data.begin();
+    int_vector::const_iterator const end = data.end();
+    result.insert(it, end);
+    return result;
+}
+
+std::unordered_multiset<int> const build_unordered_multiset()
+{
+    typedef std::unordered_set<int> int_set;
+    typedef std::unordered_multiset<int> int_multiset;
+    int_set const data = build_unordered_set();
+    return int_multiset(data.begin(), data.end());
+}
+
+std::vector<int> const init_vector()
+{
+    typedef std::vector<int> int_vector;
+    int const data[] = { -4, -3, -2, -1, 0 };
+    int_vector::size_type const data_size = sizeof(data) / sizeof(data[0]);
+    return int_vector(data, data + data_size);
+}
+
+std::vector<int> const build_vector()
+{
+    typedef std::vector<int> int_vector;
+    static int_vector data = init_vector();
+    int_vector::size_type const size = data.size();
+    int_vector::iterator it = data.begin();
+    int_vector::iterator const end = data.end();
+    for (; it != end; ++it)
+        *it += size;
+    return data;
+}
+
+int
+main()
+{
+    BOOST_STATIC_ASSERT((!phx::stl::has_mapped_type<std::unordered_multiset<int> >::value));
+    BOOST_STATIC_ASSERT((phx::stl::has_key_type<std::unordered_multiset<int> >::value));
+
+    std::unordered_multiset<int> const data = build_unordered_multiset();
+    test_begin(data);
+    test_clear(data);
+    test_empty(data);
+    test_end(data);
+    test_set_erase(data);
+    test_get_allocator(data);
+    return boost::report_errors();
+}
+
+
+
+

--- a/test/container/container_tests12b.cpp
+++ b/test/container/container_tests12b.cpp
@@ -1,0 +1,71 @@
+/*=============================================================================
+    Copyright (c) 2004 Angus Leeming
+    Copyright (c) 2017 Kohei Takahashi
+
+    Distributed under the Boost Software License, Version 1.0. (See accompanying 
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+==============================================================================*/
+#include "container_tests.hpp"
+#include <boost/static_assert.hpp>
+
+std::unordered_set<int> const build_unordered_set()
+{
+    typedef std::unordered_set<int> int_set;
+    typedef std::vector<int> int_vector;
+
+    int_set result;
+    int_vector const data = build_vector();
+    int_vector::const_iterator it = data.begin();
+    int_vector::const_iterator const end = data.end();
+    result.insert(it, end);
+    return result;
+}
+
+std::unordered_multiset<int> const build_unordered_multiset()
+{
+    typedef std::unordered_set<int> int_set;
+    typedef std::unordered_multiset<int> int_multiset;
+    int_set const data = build_unordered_set();
+    return int_multiset(data.begin(), data.end());
+}
+
+std::vector<int> const init_vector()
+{
+    typedef std::vector<int> int_vector;
+    int const data[] = { -4, -3, -2, -1, 0 };
+    int_vector::size_type const data_size = sizeof(data) / sizeof(data[0]);
+    return int_vector(data, data + data_size);
+}
+
+std::vector<int> const build_vector()
+{
+    typedef std::vector<int> int_vector;
+    static int_vector data = init_vector();
+    int_vector::size_type const size = data.size();
+    int_vector::iterator it = data.begin();
+    int_vector::iterator const end = data.end();
+    for (; it != end; ++it)
+      *it += size;
+    return data;
+}
+
+int
+main()
+{
+    BOOST_STATIC_ASSERT((!phx::stl::has_mapped_type<std::unordered_multiset<int> >::value));
+    BOOST_STATIC_ASSERT((phx::stl::has_key_type<std::unordered_multiset<int> >::value));
+
+    std::unordered_multiset<int> const data = build_unordered_multiset();
+    test_multiset_insert(data);
+    //test_key_comp(data);
+    test_max_size(data);
+    //test_rbegin(data);
+    //test_rend(data);
+    test_size(data);
+    //test_value_comp(data);
+    return boost::report_errors();
+}
+
+
+
+

--- a/test/container/container_tests1a.cpp
+++ b/test/container/container_tests1a.cpp
@@ -35,6 +35,9 @@ std::vector<int> const build_vector()
 int 
 main()
 {
+    BOOST_STATIC_ASSERT((!phx::stl::has_mapped_type<std::list<int> >::value));
+    BOOST_STATIC_ASSERT((!phx::stl::has_key_type<std::list<int> >::value));
+
     std::list<int> const data = build_list();
     test_assign(data);
     test_assign2(data);

--- a/test/container/container_tests1b.cpp
+++ b/test/container/container_tests1b.cpp
@@ -35,6 +35,9 @@ std::vector<int> const build_vector()
 int 
 main()
 {
+    BOOST_STATIC_ASSERT((!phx::stl::has_mapped_type<std::list<int> >::value));
+    BOOST_STATIC_ASSERT((!phx::stl::has_key_type<std::list<int> >::value));
+
     std::list<int> const data = build_list();
     test_empty(data);
     test_end(data);

--- a/test/container/container_tests2a.cpp
+++ b/test/container/container_tests2a.cpp
@@ -35,6 +35,9 @@ std::vector<int> const build_vector()
 int
 main()
 {
+    BOOST_STATIC_ASSERT((!phx::stl::has_mapped_type<std::list<int> >::value));
+    BOOST_STATIC_ASSERT((!phx::stl::has_key_type<std::list<int> >::value));
+
     std::list<int> const data = build_list();
     test_pop_back(data);
     test_pop_front(data);

--- a/test/container/container_tests2b.cpp
+++ b/test/container/container_tests2b.cpp
@@ -35,6 +35,9 @@ std::vector<int> const build_vector()
 int
 main()
 {
+    BOOST_STATIC_ASSERT((!phx::stl::has_mapped_type<std::list<int> >::value));
+    BOOST_STATIC_ASSERT((!phx::stl::has_key_type<std::list<int> >::value));
+
     std::list<int> const data = build_list();
     test_rbegin(data);
     test_rend(data);

--- a/test/container/container_tests3a.cpp
+++ b/test/container/container_tests3a.cpp
@@ -47,6 +47,7 @@ int
 main()
 {
     BOOST_STATIC_ASSERT((phx::stl::has_mapped_type<std::map<int, int> >::value));
+    BOOST_STATIC_ASSERT((phx::stl::has_key_type<std::map<int, int> >::value));
 
     std::map<int, int> const data = build_map();
     test_begin(data);

--- a/test/container/container_tests3b.cpp
+++ b/test/container/container_tests3b.cpp
@@ -47,6 +47,7 @@ int
 main()
 {
     BOOST_STATIC_ASSERT((phx::stl::has_mapped_type<std::map<int, int> >::value));
+    BOOST_STATIC_ASSERT((phx::stl::has_key_type<std::map<int, int> >::value));
 
     std::map<int, int> const data = build_map();
     test_map_insert(data);

--- a/test/container/container_tests4a.cpp
+++ b/test/container/container_tests4a.cpp
@@ -30,6 +30,9 @@ std::vector<int> const build_vector()
 int
 main()
 {
+    BOOST_STATIC_ASSERT((!phx::stl::has_mapped_type<std::vector<int> >::value));
+    BOOST_STATIC_ASSERT((!phx::stl::has_key_type<std::vector<int> >::value));
+
     std::vector<int> const data = build_vector();
     test_assign(data);
     test_assign2(data);

--- a/test/container/container_tests4b.cpp
+++ b/test/container/container_tests4b.cpp
@@ -30,6 +30,9 @@ std::vector<int> const build_vector()
 int
 main()
 {
+    BOOST_STATIC_ASSERT((!phx::stl::has_mapped_type<std::vector<int> >::value));
+    BOOST_STATIC_ASSERT((!phx::stl::has_key_type<std::vector<int> >::value));
+
     std::vector<int> const data = build_vector();
     test_get_allocator(data);
     test_insert(data);

--- a/test/container/container_tests5a.cpp
+++ b/test/container/container_tests5a.cpp
@@ -35,6 +35,9 @@ std::vector<int> const build_vector()
 int
 main()
 {
+    BOOST_STATIC_ASSERT((!phx::stl::has_mapped_type<std::deque<int> >::value));
+    BOOST_STATIC_ASSERT((!phx::stl::has_key_type<std::deque<int> >::value));
+
     std::deque<int> const data = build_deque();
     test_assign(data);
     test_assign2(data);

--- a/test/container/container_tests5b.cpp
+++ b/test/container/container_tests5b.cpp
@@ -35,6 +35,9 @@ std::vector<int> const build_vector()
 int
 main()
 {
+    BOOST_STATIC_ASSERT((!phx::stl::has_mapped_type<std::deque<int> >::value));
+    BOOST_STATIC_ASSERT((!phx::stl::has_key_type<std::deque<int> >::value));
+
     std::deque<int> const data = build_deque();
     test_insert(data);
     test_max_size(data);

--- a/test/container/container_tests6a.cpp
+++ b/test/container/container_tests6a.cpp
@@ -54,6 +54,9 @@ std::vector<int> const build_vector()
 int
 main()
 {
+    BOOST_STATIC_ASSERT((phx::stl::has_mapped_type<std::multimap<int, int> >::value));
+    BOOST_STATIC_ASSERT((phx::stl::has_key_type<std::multimap<int, int> >::value));
+
     std::multimap<int, int> const data = build_multimap();
     test_begin(data);
     test_clear(data);

--- a/test/container/container_tests6b.cpp
+++ b/test/container/container_tests6b.cpp
@@ -54,6 +54,9 @@ std::vector<int> const build_vector()
 int
 main()
 {
+    BOOST_STATIC_ASSERT((phx::stl::has_mapped_type<std::multimap<int, int> >::value));
+    BOOST_STATIC_ASSERT((phx::stl::has_key_type<std::multimap<int, int> >::value));
+
     std::multimap<int, int> const data = build_multimap();
     test_multimap_insert(data);
     test_key_comp(data);

--- a/test/container/container_tests7a.cpp
+++ b/test/container/container_tests7a.cpp
@@ -1,0 +1,58 @@
+/*=============================================================================
+    Copyright (c) 2004 Angus Leeming
+    Copyright (c) 2017 Kohei Takahashi
+
+    Distributed under the Boost Software License, Version 1.0. (See accompanying 
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+==============================================================================*/
+#include "container_tests.hpp"
+#include <boost/static_assert.hpp>
+
+std::set<int> const build_set()
+{
+    typedef std::set<int> int_set;
+    typedef std::vector<int> int_vector;
+
+    int_set result;
+    int_vector const data = build_vector();
+    int_vector::const_iterator it = data.begin();
+    int_vector::const_iterator const end = data.end();
+    result.insert(it, end);
+    return result;
+}
+
+std::vector<int> const init_vector()
+{
+    typedef std::vector<int> int_vector;
+    int const data[] = { -4, -3, -2, -1, 0 };
+    int_vector::size_type const data_size = sizeof(data) / sizeof(data[0]);
+    return int_vector(data, data + data_size);
+}
+
+std::vector<int> const build_vector()
+{
+    typedef std::vector<int> int_vector;
+    static int_vector data = init_vector();
+    int_vector::size_type const size = data.size();
+    int_vector::iterator it = data.begin();
+    int_vector::iterator const end = data.end();
+    for (; it != end; ++it)
+      *it += size;
+    return data;
+}
+
+int
+main()
+{
+    BOOST_STATIC_ASSERT((!phx::stl::has_mapped_type<std::set<int> >::value));
+
+    std::set<int> const data = build_set();
+    test_begin(data);
+    test_clear(data);
+    test_empty(data);
+    test_end(data);
+    test_set_erase(data);
+    test_get_allocator(data);
+    return boost::report_errors();
+}
+

--- a/test/container/container_tests7a.cpp
+++ b/test/container/container_tests7a.cpp
@@ -45,6 +45,7 @@ int
 main()
 {
     BOOST_STATIC_ASSERT((!phx::stl::has_mapped_type<std::set<int> >::value));
+    BOOST_STATIC_ASSERT((phx::stl::has_key_type<std::set<int> >::value));
 
     std::set<int> const data = build_set();
     test_begin(data);

--- a/test/container/container_tests7b.cpp
+++ b/test/container/container_tests7b.cpp
@@ -45,6 +45,7 @@ int
 main()
 {
     BOOST_STATIC_ASSERT((!phx::stl::has_mapped_type<std::set<int> >::value));
+    BOOST_STATIC_ASSERT((phx::stl::has_key_type<std::set<int> >::value));
 
     std::set<int> const data = build_set();
     test_set_insert(data);

--- a/test/container/container_tests7b.cpp
+++ b/test/container/container_tests7b.cpp
@@ -1,0 +1,59 @@
+/*=============================================================================
+    Copyright (c) 2004 Angus Leeming
+    Copyright (c) 2017 Kohei Takahashi
+
+    Distributed under the Boost Software License, Version 1.0. (See accompanying 
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+==============================================================================*/
+#include "container_tests.hpp"
+#include <boost/static_assert.hpp>
+
+std::set<int> const build_set()
+{
+    typedef std::set<int> int_set;
+    typedef std::vector<int> int_vector;
+
+    int_set result;
+    int_vector const data = build_vector();
+    int_vector::const_iterator it = data.begin();
+    int_vector::const_iterator const end = data.end();
+    result.insert(it, end);
+    return result;
+}
+
+std::vector<int> const init_vector()
+{
+    typedef std::vector<int> int_vector;
+    int const data[] = { -4, -3, -2, -1, 0 };
+    int_vector::size_type const data_size = sizeof(data) / sizeof(data[0]);
+    return int_vector(data, data + data_size);
+}
+
+std::vector<int> const build_vector()
+{
+    typedef std::vector<int> int_vector;
+    static int_vector data = init_vector();
+    int_vector::size_type const size = data.size();
+    int_vector::iterator it = data.begin();
+    int_vector::iterator const end = data.end();
+    for (; it != end; ++it)
+        *it += size;
+    return data;
+}
+
+int
+main()
+{
+    BOOST_STATIC_ASSERT((!phx::stl::has_mapped_type<std::set<int> >::value));
+
+    std::set<int> const data = build_set();
+    test_set_insert(data);
+    test_key_comp(data);
+    test_max_size(data);
+    test_rbegin(data);
+    test_rend(data);
+    test_size(data);
+    test_value_comp(data);
+    return boost::report_errors();
+}
+

--- a/test/container/container_tests8a.cpp
+++ b/test/container/container_tests8a.cpp
@@ -53,6 +53,7 @@ int
 main()
 {
     BOOST_STATIC_ASSERT((!phx::stl::has_mapped_type<std::multiset<int> >::value));
+    BOOST_STATIC_ASSERT((phx::stl::has_key_type<std::multiset<int> >::value));
 
     std::multiset<int> const data = build_multiset();
     test_begin(data);

--- a/test/container/container_tests8a.cpp
+++ b/test/container/container_tests8a.cpp
@@ -1,0 +1,69 @@
+/*=============================================================================
+    Copyright (c) 2004 Angus Leeming
+    Copyright (c) 2017 Kohei Takahashi
+
+    Distributed under the Boost Software License, Version 1.0. (See accompanying 
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+==============================================================================*/
+#include "container_tests.hpp"
+#include <boost/static_assert.hpp>
+
+std::set<int> const build_set()
+{
+    typedef std::set<int> int_set;
+    typedef std::vector<int> int_vector;
+
+    int_set result;
+    int_vector const data = build_vector();
+    int_vector::const_iterator it = data.begin();
+    int_vector::const_iterator const end = data.end();
+    result.insert(it, end);
+    return result;
+}
+
+std::multiset<int> const build_multiset()
+{
+    typedef std::set<int> int_set;
+    typedef std::multiset<int> int_multiset;
+    int_set const data = build_set();
+    return int_multiset(data.begin(), data.end());
+}
+
+std::vector<int> const init_vector()
+{
+    typedef std::vector<int> int_vector;
+    int const data[] = { -4, -3, -2, -1, 0 };
+    int_vector::size_type const data_size = sizeof(data) / sizeof(data[0]);
+    return int_vector(data, data + data_size);
+}
+
+std::vector<int> const build_vector()
+{
+    typedef std::vector<int> int_vector;
+    static int_vector data = init_vector();
+    int_vector::size_type const size = data.size();
+    int_vector::iterator it = data.begin();
+    int_vector::iterator const end = data.end();
+    for (; it != end; ++it)
+        *it += size;
+    return data;
+}
+
+int
+main()
+{
+    BOOST_STATIC_ASSERT((!phx::stl::has_mapped_type<std::multiset<int> >::value));
+
+    std::multiset<int> const data = build_multiset();
+    test_begin(data);
+    test_clear(data);
+    test_empty(data);
+    test_end(data);
+    test_set_erase(data);
+    test_get_allocator(data);
+    return boost::report_errors();
+}
+
+
+
+

--- a/test/container/container_tests8b.cpp
+++ b/test/container/container_tests8b.cpp
@@ -53,6 +53,7 @@ int
 main()
 {
     BOOST_STATIC_ASSERT((!phx::stl::has_mapped_type<std::multiset<int> >::value));
+    BOOST_STATIC_ASSERT((phx::stl::has_key_type<std::multiset<int> >::value));
 
     std::multiset<int> const data = build_multiset();
     test_multiset_insert(data);

--- a/test/container/container_tests8b.cpp
+++ b/test/container/container_tests8b.cpp
@@ -1,0 +1,70 @@
+/*=============================================================================
+    Copyright (c) 2004 Angus Leeming
+    Copyright (c) 2017 Kohei Takahashi
+
+    Distributed under the Boost Software License, Version 1.0. (See accompanying 
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+==============================================================================*/
+#include "container_tests.hpp"
+#include <boost/static_assert.hpp>
+
+std::set<int> const build_set()
+{
+    typedef std::set<int> int_set;
+    typedef std::vector<int> int_vector;
+
+    int_set result;
+    int_vector const data = build_vector();
+    int_vector::const_iterator it = data.begin();
+    int_vector::const_iterator const end = data.end();
+    result.insert(it, end);
+    return result;
+}
+
+std::multiset<int> const build_multiset()
+{
+    typedef std::set<int> int_set;
+    typedef std::multiset<int> int_multiset;
+    int_set const data = build_set();
+    return int_multiset(data.begin(), data.end());
+}
+
+std::vector<int> const init_vector()
+{
+    typedef std::vector<int> int_vector;
+    int const data[] = { -4, -3, -2, -1, 0 };
+    int_vector::size_type const data_size = sizeof(data) / sizeof(data[0]);
+    return int_vector(data, data + data_size);
+}
+
+std::vector<int> const build_vector()
+{
+    typedef std::vector<int> int_vector;
+    static int_vector data = init_vector();
+    int_vector::size_type const size = data.size();
+    int_vector::iterator it = data.begin();
+    int_vector::iterator const end = data.end();
+    for (; it != end; ++it)
+      *it += size;
+    return data;
+}
+
+int
+main()
+{
+    BOOST_STATIC_ASSERT((!phx::stl::has_mapped_type<std::multiset<int> >::value));
+
+    std::multiset<int> const data = build_multiset();
+    test_multiset_insert(data);
+    test_key_comp(data);
+    test_max_size(data);
+    test_rbegin(data);
+    test_rend(data);
+    test_size(data);
+    test_value_comp(data);
+    return boost::report_errors();
+}
+
+
+
+

--- a/test/container/container_tests9a.cpp
+++ b/test/container/container_tests9a.cpp
@@ -1,0 +1,62 @@
+/*=============================================================================
+    Copyright (c) 2004 Angus Leeming
+    Copyright (c) 2017 Kohei Takahashi
+
+    Distributed under the Boost Software License, Version 1.0. (See accompanying 
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+==============================================================================*/
+#include "container_tests.hpp"
+#include <boost/static_assert.hpp>
+
+std::unordered_map<int, int> const build_unordered_map()
+{
+    typedef std::unordered_map<int, int> int_map;
+    typedef std::vector<int> int_vector;
+
+    int_map result;
+    int_vector const data = build_vector();
+    int_vector::const_iterator it = data.begin();
+    int_vector::const_iterator const end = data.end();
+    for (; it != end; ++it) {
+      int const value = *it;
+      result[value] = 100 * value;
+    }
+    return result;
+}
+
+std::vector<int> const init_vector()
+{
+    typedef std::vector<int> int_vector;
+    int const data[] = { -4, -3, -2, -1, 0 };
+    int_vector::size_type const data_size = sizeof(data) / sizeof(data[0]);
+    return int_vector(data, data + data_size);
+}
+
+std::vector<int> const build_vector()
+{
+    typedef std::vector<int> int_vector;
+    static int_vector data = init_vector();
+    int_vector::size_type const size = data.size();
+    int_vector::iterator it = data.begin();
+    int_vector::iterator const end = data.end();
+    for (; it != end; ++it)
+      *it += size;
+    return data;
+}
+
+int
+main()
+{
+    BOOST_STATIC_ASSERT((phx::stl::has_mapped_type<std::unordered_map<int, int> >::value));
+    BOOST_STATIC_ASSERT((phx::stl::has_key_type<std::unordered_map<int, int> >::value));
+
+    std::unordered_map<int, int> const data = build_unordered_map();
+    test_begin(data);
+    test_clear(data);
+    test_empty(data);
+    test_end(data);
+    test_map_erase(data);
+    test_get_allocator(data);
+    return boost::report_errors();
+}
+

--- a/test/container/container_tests9b.cpp
+++ b/test/container/container_tests9b.cpp
@@ -1,0 +1,63 @@
+/*=============================================================================
+    Copyright (c) 2004 Angus Leeming
+    Copyright (c) 2017 Kohei Takahashi
+
+    Distributed under the Boost Software License, Version 1.0. (See accompanying 
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+==============================================================================*/
+#include "container_tests.hpp"
+#include <boost/static_assert.hpp>
+
+std::unordered_map<int, int> const build_unordered_map()
+{
+    typedef std::unordered_map<int, int> int_map;
+    typedef std::vector<int> int_vector;
+
+    int_map result;
+    int_vector const data = build_vector();
+    int_vector::const_iterator it = data.begin();
+    int_vector::const_iterator const end = data.end();
+    for (; it != end; ++it) {
+      int const value = *it;
+      result[value] = 100 * value;
+    }
+    return result;
+}
+
+std::vector<int> const init_vector()
+{
+    typedef std::vector<int> int_vector;
+    int const data[] = { -4, -3, -2, -1, 0 };
+    int_vector::size_type const data_size = sizeof(data) / sizeof(data[0]);
+    return int_vector(data, data + data_size);
+}
+
+std::vector<int> const build_vector()
+{
+    typedef std::vector<int> int_vector;
+    static int_vector data = init_vector();
+    int_vector::size_type const size = data.size();
+    int_vector::iterator it = data.begin();
+    int_vector::iterator const end = data.end();
+    for (; it != end; ++it)
+        *it += size;
+    return data;
+}
+
+int
+main()
+{
+    BOOST_STATIC_ASSERT((phx::stl::has_mapped_type<std::unordered_map<int, int> >::value));
+    BOOST_STATIC_ASSERT((phx::stl::has_key_type<std::unordered_map<int, int> >::value));
+
+    std::unordered_map<int, int> const data = build_unordered_map();
+    test_map_insert(data);
+    //test_key_comp(data);
+    test_max_size(data);
+    //test_rbegin(data);
+    //test_rend(data);
+    test_size(data);
+    //test_value_comp(data);
+    return boost::report_errors();
+}
+


### PR DESCRIPTION
This PR includes following features:
- Added support for `std::set` and `std::multiset`.
- Fixed [#7423](https://svn.boost.org/trac/boost/ticket/7423) `std::map::erase returns iterator in C++11 mode instead of void, should be handled properly` .
- Added tests for C++11 unordered associative containers.

Tested:
- GCC 7.1.1 20170503 (Red Hat 7.1.1-1)
    - gnu++98 / 11 / 14 / 1z
- Clang 4.0.0
    - gnu++98 / 11 / 14 / 1z
- MSVC
    - 8 / 9sp1 / 10sp1 / 11u5 / 12u5 / 14u3 / 14.1