### PR TITLE
C++11: Fixed bug with initializing phoenix lazy from array types

### DIFF
--- a/include/boost/phoenix/core/expression.hpp
+++ b/include/boost/phoenix/core/expression.hpp
@@ -27,22 +27,26 @@ namespace boost { namespace phoenix
     template <template <typename> class Actor, typename Tag, typename... A>
     struct expr_ext;
 
-    // This void filter is necessary to avoid forming reference to void
-    // because most of other expressions are not based on variadics.
-    template <typename Tag, typename F, typename... T>
+    // This filter cuts arguments of a template pack after a first void.
+    // It is necessary because the interface can be used in C++03 style.
+    template <typename Tag, typename... A>
     struct expr_impl;
 
+    // Helper template. Used to store filtered argument types.
+    template <typename... A>
+    struct expr_arg_types {};
+
     template <typename Tag, typename... A>
-    struct expr_impl<Tag, void(A...)> : expr_ext<actor, Tag, A...> {};
+    struct expr_impl<Tag, expr_arg_types<A...>> : expr_ext<actor, Tag, A...> {};
 
     template <typename Tag, typename... A, typename... T>
-    struct expr_impl<Tag, void(A...), void, T...> : expr_impl<Tag, void(A...)> {};
+    struct expr_impl<Tag, expr_arg_types<A...>, void, T...> : expr_ext<actor, Tag, A...> {};
 
     template <typename Tag, typename... A, typename H, typename... T>
-    struct expr_impl<Tag, void(A...), H, T...> : expr_impl<Tag, void(A..., H), T...> {};
+    struct expr_impl<Tag, expr_arg_types<A...>, H, T...> : expr_impl<Tag, expr_arg_types<A..., H>, T...> {};
 
     template <typename Tag, typename... A>
-    struct expr : expr_impl<Tag, void(), A...> {};
+    struct expr : expr_impl<Tag, expr_arg_types<>, A...> {};
 
     template <template <typename> class Actor, typename Tag, typename... A>
     struct expr_ext

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -211,6 +211,7 @@ test-suite phoenix_regression :
     [ run regression/bug7165.cpp ]
     [ compile-fail regression/bug7166.cpp ]
     [ run regression/bug7624.cpp ]
+    [ compile regression/from_array.cpp ]
     ;
 
 test-suite phoenix_include :

--- a/test/regression/from_array.cpp
+++ b/test/regression/from_array.cpp
@@ -1,0 +1,22 @@
+/*=============================================================================
+    Copyright (c) 2017 Nikita Kniazev
+
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+==============================================================================*/
+
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/object.hpp>
+
+#include <boost/array.hpp>
+#include <string>
+
+int main()
+{
+    (void) boost::phoenix::construct<std::string>("str");
+
+    int ints[] = { 1, 2, 3 };
+    (void) boost::phoenix::construct<boost::array<int, sizeof(ints)> >(ints);
+
+    return 0;
+}


### PR DESCRIPTION
Type `const T [N]` decays to `T *const` when you place it into a function signature.

Closes https://svn.boost.org/trac10/ticket/12733.