### PR TITLE
Inheriting std::iterator is deprecated in c++17.

### DIFF
--- a/include/boost/phoenix/function/lazy_list.hpp
+++ b/include/boost/phoenix/function/lazy_list.hpp
@@ -388,8 +388,7 @@ void intrusive_ptr_release( const strict_cons<T>* p ) {
 }
 
 template <class T>
-class strict_list_iterator
-: public std::iterator<std::input_iterator_tag,T,ptrdiff_t> {
+class strict_list_iterator {
    typedef boost::intrusive_ptr<strict_cons<T> > rep_type;
    rep_type l;
    bool is_nil;
@@ -406,6 +405,12 @@ class strict_list_iterator
       const T* operator->() const { return &x; }
    };
 public:
+   typedef std::input_iterator_tag iterator_category;
+   typedef T value_type;
+   typedef ptrdiff_t difference_type;
+   typedef T* pointer;
+   typedef T& reference;
+
    strict_list_iterator() : l(), is_nil(true) {}
    explicit strict_list_iterator( const rep_type& ll ) : l(ll), is_nil(!ll) {}
    
@@ -991,8 +996,7 @@ template <class T, class F> struct ListHelp<T,F,odd_list<T> > {
 };
 
 template <class T>
-class list_iterator
-: public std::iterator<std::input_iterator_tag,T,ptrdiff_t> {
+class list_iterator {
    list<T> l;
    bool is_nil;
    void advance() {
@@ -1008,6 +1012,12 @@ class list_iterator
       const T* operator->() const { return &x; }
    };
 public:
+   typedef std::input_iterator_tag iterator_category;
+   typedef T value_type;
+   typedef ptrdiff_t difference_type;
+   typedef T* pointer;
+   typedef T& reference;
+
    list_iterator() : l(), is_nil(true) {}
    explicit list_iterator( const list<T>& ll ) : l(ll), is_nil(!ll) {}
    


### PR DESCRIPTION
Therefore get rid of all of that and replace inheritance by lifting std::iterator's members into the derived class.

Signed-off-by: Daniela Engert <dani@ngrt.de>