### PR TITLE
Repair custom terminal support

### DIFF
--- a/include/boost/phoenix/core/actor.hpp
+++ b/include/boost/phoenix/core/actor.hpp
@@ -143,7 +143,7 @@ namespace boost { namespace phoenix
             >::type
             expr_type;
 
-        BOOST_PROTO_BASIC_EXTENDS(expr_type, actor<expr_type>, phoenix_domain)
+        BOOST_PROTO_BASIC_EXTENDS(expr_type, actor<Expr>, phoenix_domain)
         BOOST_PROTO_EXTENDS_SUBSCRIPT()
         BOOST_PROTO_EXTENDS_ASSIGN()
 


### PR DESCRIPTION
PR #64 had broken custom terminal support. The phoenix test suite seems does not cover this part, but the fix is enough to make Spirit pass its own tests.

Note: `BOOST_PROTO_BASIC_EXTENDS(Expr, actor<Expr>, phoenix_domain)` does not work out.