### PR TITLE
Actor is taken by reference on assignment/subscript

### DIFF
--- a/include/boost/phoenix/core/domain.hpp
+++ b/include/boost/phoenix/core/domain.hpp
@@ -33,6 +33,24 @@ namespace boost { namespace phoenix
         {};
     };
 
+    // proto's assignment operator takes rhs by reference
+    template<>
+    struct phoenix_generator::case_<proto::tag::assign>
+      : proto::otherwise<proto::call<proto::compose_generators<
+            proto::by_value_generator
+          , proto::pod_generator<actor>
+        >(proto::_)> >
+    {};
+
+    // proto's subscript operator takes rhs by reference
+    template<>
+    struct phoenix_generator::case_<proto::tag::subscript>
+      : proto::otherwise<proto::call<proto::compose_generators<
+            proto::by_value_generator
+          , proto::pod_generator<actor>
+        >(proto::_)> >
+    {};
+
     struct phoenix_default_domain
         : proto::domain<
            proto::basic_default_generator

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -226,6 +226,7 @@ test-suite phoenix_regression :
     [ compile-fail regression/bug7166.cpp ]
     [ run regression/bug7624.cpp ]
     [ compile regression/from_array.cpp ]
+    [ run regression/actor_assignment.cpp ]
     ;
 
 test-suite phoenix_include :

--- a/test/regression/actor_assignment.cpp
+++ b/test/regression/actor_assignment.cpp
@@ -1,0 +1,29 @@
+/*=============================================================================
+    Copyright (c) 2018 Nikita Kniazev
+
+    Distributed under the Boost Software License, Version 1.0. (See accompanying 
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+==============================================================================*/
+
+#include <boost/detail/lightweight_test.hpp>
+#include <boost/phoenix.hpp>
+#include <boost/function.hpp>
+#include <string>
+
+// Checks that rhs Phoenix actor is taken by value on assignment.
+// The wrapper function is used to ensure that created temporaries are
+// out of scope (as they will be created on the other stack frame).
+
+boost::function<void()> make_assignment_test(std::string & s)
+{
+    return boost::phoenix::ref(s) = "asd";
+}
+
+int main()
+{
+    std::string s;
+    make_assignment_test(s)();
+    BOOST_TEST(s == "asd");
+
+    return boost::report_errors();
+}


### PR DESCRIPTION
It looks like I have found the reason why assignment/subscript operators were defined by hand (ref #64) but not with `BOOST_PROTO_EXTENDS_SUBSCRIPT`/`BOOST_PROTO_EXTENDS_ASSIGN`.

For unknown reason proto's assignment and subscript operators takes rhs by reference while other operators takes both arguments by value.

Example:
```cpp
    std::cout << typeid(decltype(boost::phoenix::ref(s) = "asd")).name() << std::endl;
    std::cout << typeid(decltype(boost::phoenix::ref(s) + "asd")).name() << std::endl;
```
```
boost::phoenix::actor<
    boost::proto::exprns_::basic_expr<
        boost::proto::tagns_::tag::assign
      , boost::proto::argsns_::list2<
            boost::phoenix::actor<
                boost::proto::exprns_::basic_expr<
                    boost::proto::tagns_::tag::terminal
                  , boost::proto::argsns_::term<
                        boost::reference_wrapper<
                            std::basic_string<
                                char
                              , std::char_traits<char>
                              , std::allocator<char>
                            >
                        >
                    >
                  , 0
                >
            > const & /////////////////////////// HERE
          , boost::phoenix::actor<
                boost::proto::exprns_::basic_expr<
                    boost::proto::tagns_::tag::terminal
                  , boost::proto::argsns_::term<char>
                  , 0
                >
            >
        >
      , 2
    >
>

boost::phoenix::actor<
    boost::proto::exprns_::basic_expr<
        boost::proto::tagns_::tag::plus
      , boost::proto::argsns_::list2<
            boost::phoenix::actor<
                boost::proto::exprns_::basic_expr<
                    boost::proto::tagns_::tag::terminal
                  , boost::proto::argsns_::term<
                        boost::reference_wrapper<
                            std::basic_string<
                                char
                              , std::char_traits<char>
                              , std::allocator<char>
                            >
                        >
                    >
                  , 0
                >
            > /////////////////////////// HERE
          , boost::phoenix::actor<
                boost::proto::exprns_::basic_expr<
                    boost::proto::tagns_::tag::terminal
                  , boost::proto::argsns_::term<char>
                  , 0
                >
            >
        >
      , 2
    >
>
```
