### PR TITLE
Do not include the whole Predef library

### DIFF
--- a/include/boost/phoenix/version.hpp
+++ b/include/boost/phoenix/version.hpp
@@ -16,17 +16,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 #define BOOST_PHOENIX_VERSION   0x3200    // 3.2.0
 
-// boost/predef is not in Boost before 1.55.0
-#include <boost/version.hpp>
-#if BOOST_VERSION >= 105500
-// Also note that it has a nonstandard header which could change,
-// so I have not relied on its own internal define.
-#include <boost/predef.h>
-#define BOOST_PHOENIX_HAVE_BOOST_PREDEF
-#endif
-
-#ifdef BOOST_PHOENIX_HAVE_BOOST_PREDEF
+#include <boost/predef/version_number.h>
 #define BOOST_PHOENIX_VERSION_NUMBER = BOOST_VERSION_NUMBER(3,2,0)
-#endif
 
 #endif


### PR DESCRIPTION
Because of a single macro definition Phoenix includes the whole Predef library.

Actually I am not sure what are the reasons to have `BOOST_PHOENIX_VERSION_NUMBER` macro. It was added by @fletchjp in a big commit 6a094019ee2050607cfaebd2b10834c59a7bd31e without a comment.