### PR TITLE
Move debug out of core

### DIFF
--- a/include/boost/phoenix/core.hpp
+++ b/include/boost/phoenix/core.hpp
@@ -10,7 +10,6 @@
 #include <boost/phoenix/version.hpp>
 #include <boost/phoenix/core/limits.hpp>
 #include <boost/phoenix/core/actor.hpp>
-#include <boost/phoenix/core/debug.hpp>
 #include <boost/phoenix/core/is_actor.hpp>
 #include <boost/phoenix/core/argument.hpp>
 #include <boost/phoenix/core/value.hpp>

--- a/include/boost/phoenix/core/debug.hpp
+++ b/include/boost/phoenix/core/debug.hpp
@@ -1,0 +1,18 @@
+/*==============================================================================
+    Copyright (c) 2005-2010 Joel de Guzman
+    Copyright (c) 2010 Thomas Heller
+    Copyright (c) 2014 John Fletcher
+ 
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+==============================================================================*/
+#ifndef BOOST_PHOENIX_CORE_DEBUG_HPP
+#define BOOST_PHOENIX_CORE_DEBUG_HPP
+
+#include <boost/config/header_deprecated.hpp>
+
+BOOST_HEADER_DEPRECATED("<boost/phoenix/debug.hpp>")
+
+#include <boost/phoenix/debug.hpp>
+
+#endif

--- a/include/boost/phoenix/debug.hpp
+++ b/include/boost/phoenix/debug.hpp
@@ -6,8 +6,8 @@
     Distributed under the Boost Software License, Version 1.0. (See accompanying
     file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 ==============================================================================*/
-#ifndef BOOST_PHOENIX_CORE_DEBUG_HPP
-#define BOOST_PHOENIX_CORE_DEBUG_HPP
+#ifndef BOOST_PHOENIX_DEBUG_HPP
+#define BOOST_PHOENIX_DEBUG_HPP
 
 #include <iostream>
 #include <boost/phoenix/version.hpp>

--- a/include/boost/phoenix/phoenix.hpp
+++ b/include/boost/phoenix/phoenix.hpp
@@ -9,6 +9,7 @@
 #define BOOST_PHOENIX_PHOENIX_HPP
 
 #include <boost/phoenix/core.hpp>
+#include <boost/phoenix/debug.hpp>
 #include <boost/phoenix/function.hpp>
 #include <boost/phoenix/operator.hpp>
 #include <boost/phoenix/statement.hpp>


### PR DESCRIPTION
The header is not mandatory, but currently it brings iostream to every Phoenix usage.