### PR TITLE
Remove obsolete Fusion bug workaround

### DIFF
--- a/include/boost/phoenix/operator/comparison.hpp
+++ b/include/boost/phoenix/operator/comparison.hpp
@@ -11,7 +11,6 @@
 #include <boost/phoenix/operator/detail/define_operator.hpp>
 #include <boost/phoenix/core/expression.hpp>
 #include <boost/proto/operators.hpp>
-#include <boost/proto/fusion.hpp> // Added to solve bug 6268
 
 namespace boost { namespace phoenix
 {


### PR DESCRIPTION
Including the header were just hiding a bug in Fusion, since the bug was fixed (https://github.com/boostorg/fusion/pull/216) the workaround is obsolete.

There is a test for the bug in Phoenix, it could be also removed.