### PR TITLE
mem_fun_ptr store ptr actor by value 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -193,7 +193,7 @@ matrix:
 
     - os: linux
       dist: xenial
-      env: TOOLSET=gcc-9 CXXSTD=03,11,14
+      env: TOOLSET=gcc-9 CXXSTD=03,11,14 SANITIZED
       addons:
         apt:
           packages:
@@ -203,7 +203,7 @@ matrix:
 
     - os: linux
       dist: xenial
-      env: TOOLSET=gcc-9 CXXSTD=17,2a
+      env: TOOLSET=gcc-9 CXXSTD=17,2a SANITIZED
       addons:
         apt:
           packages:
@@ -380,7 +380,7 @@ matrix:
 
     - os: linux
       dist: xenial
-      env: TOOLSET=clang-7.0 CXXSTD=14,17
+      env: TOOLSET=clang-7 CXXSTD=14,17
       addons:
         apt:
           packages:
@@ -390,7 +390,7 @@ matrix:
 
     - os: linux
       dist: xenial
-      env: TOOLSET=clang-7.0 CXXSTD=2a
+      env: TOOLSET=clang-7 CXXSTD=2a
       addons:
         apt:
           packages:
@@ -416,7 +416,7 @@ matrix:
 
     - os: linux
       dist: bionic
-      env: TOOLSET=clang-9 CXXSTD=03,11,14
+      env: TOOLSET=clang-9 CXXSTD=03,11,14 SANITIZED
       addons:
         apt:
           packages:
@@ -424,7 +424,7 @@ matrix:
 
     - os: linux
       dist: bionic
-      env: TOOLSET=clang-9 CXXSTD=17,2a
+      env: TOOLSET=clang-9 CXXSTD=17,2a SANITIZED
       addons:
         apt:
           packages:
@@ -529,3 +529,5 @@ install:
 
 script:
   - ./b2 libs/phoenix/test toolset=$TOOLSET cxxstd=$CXXSTD
+      ${SANITIZED+cxxflags=-fsanitize=address,undefined}
+      ${SANITIZED+'linkflags=-fsanitize=address,undefined -fuse-ld=gold'}

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ language: cpp
 
 sudo: false
 
+cache: ccache
+
 os:
   - linux
   - osx
@@ -370,7 +372,7 @@ matrix:
 
     - os: linux
       dist: xenial
-      env: TOOLSET=clang-7.0 CXXSTD=03,11
+      env: TOOLSET=clang-7 CXXSTD=03,11
       addons:
         apt:
           packages:
@@ -526,6 +528,14 @@ install:
 
   - ./bootstrap.sh
   - ./b2 headers
+
+  - |
+    if [ $TRAVIS_OS_NAME = osx ]; then
+      export PATH="/usr/local/opt/ccache/libexec:$PATH"
+      brew install ccache
+    fi
+  - |-
+    echo "using ${TOOLSET%%-*} : ${TOOLSET#*-} : ccache `echo $TOOLSET | sed 's/clang/clang++/;s/gcc/g++/'` ;" > ~/user-config.jam
 
 script:
   - ./b2 libs/phoenix/test toolset=$TOOLSET cxxstd=$CXXSTD

--- a/.travis.yml
+++ b/.travis.yml
@@ -193,6 +193,26 @@ matrix:
 
     - os: linux
       dist: xenial
+      env: TOOLSET=gcc-9 CXXSTD=03,11,14
+      addons:
+        apt:
+          packages:
+            - g++-9
+          sources:
+            - ubuntu-toolchain-r-test
+
+    - os: linux
+      dist: xenial
+      env: TOOLSET=gcc-9 CXXSTD=17,2a
+      addons:
+        apt:
+          packages:
+            - g++-9
+          sources:
+            - ubuntu-toolchain-r-test
+
+    - os: linux
+      dist: xenial
       env: TOOLSET=clang-3.5 CXXSTD=03,11
       addons:
         apt:
@@ -377,6 +397,38 @@ matrix:
             - clang-7
           sources:
             - llvm-toolchain-xenial-7
+
+    - os: linux
+      dist: xenial
+      env: TOOLSET=clang-8 CXXSTD=03,11,14
+      addons:
+        apt:
+          packages:
+            - clang-8
+
+    - os: linux
+      dist: xenial
+      env: TOOLSET=clang-8 CXXSTD=17,2a
+      addons:
+        apt:
+          packages:
+            - clang-8
+
+    - os: linux
+      dist: bionic
+      env: TOOLSET=clang-9 CXXSTD=03,11,14
+      addons:
+        apt:
+          packages:
+            - clang-9
+
+    - os: linux
+      dist: bionic
+      env: TOOLSET=clang-9 CXXSTD=17,2a
+      addons:
+        apt:
+          packages:
+            - clang-9
 
     - os: osx
       env: TOOLSET=clang COMPILER=clang++ CXXSTD=03,11

--- a/.travis.yml
+++ b/.travis.yml
@@ -199,13 +199,14 @@ matrix:
           packages:
             - clang-3.5
 
-    - os: linux
-      dist: xenial
-      env: TOOLSET=clang-3.5 CXXSTD=14,1z
-      addons:
-        apt:
-          packages:
-            - clang-3.5
+    # Disable due to: error: debug information for auto is not yet supported
+    #- os: linux
+    #  dist: xenial
+    #  env: TOOLSET=clang-3.5 CXXSTD=14,1z
+    #  addons:
+    #    apt:
+    #      packages:
+    #        - clang-3.5
 
     - os: linux
       dist: xenial

--- a/.travis.yml
+++ b/.travis.yml
@@ -476,4 +476,4 @@ install:
   - ./b2 headers
 
 script:
-  - ./b2 -j`(nproc || sysctl -n hw.ncpu) 2> /dev/null` libs/phoenix/test toolset=$TOOLSET cxxstd=$CXXSTD
+  - ./b2 libs/phoenix/test toolset=$TOOLSET cxxstd=$CXXSTD

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -134,4 +134,4 @@ install:
 build: off
 
 test_script:
-  - b2 -j%NUMBER_OF_PROCESSORS% --hash libs/phoenix/test toolset=%TOOLSET% cxxstd=%CXXSTD%
+  - b2 --hash libs/phoenix/test toolset=%TOOLSET% cxxstd=%CXXSTD%

--- a/include/boost/phoenix/operator/detail/cpp03/mem_fun_ptr_gen.hpp
+++ b/include/boost/phoenix/operator/detail/cpp03/mem_fun_ptr_gen.hpp
@@ -44,7 +44,7 @@
 
 #include BOOST_PHOENIX_ITERATE()
 
-            Object const& obj;
+            Object obj;
             MemPtr ptr;
 
         };

--- a/include/boost/phoenix/operator/detail/cpp03/preprocessed/mem_fun_ptr_gen_10.hpp
+++ b/include/boost/phoenix/operator/detail/cpp03/preprocessed/mem_fun_ptr_gen_10.hpp
@@ -207,7 +207,7 @@
                   , A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , A8
                 >::make(obj, ptr, a0 , a1 , a2 , a3 , a4 , a5 , a6 , a7 , a8);
             }
-            Object const& obj;
+            Object obj;
             MemPtr ptr;
         };
         struct make_mem_fun_ptr_gen

--- a/include/boost/phoenix/operator/detail/cpp03/preprocessed/mem_fun_ptr_gen_20.hpp
+++ b/include/boost/phoenix/operator/detail/cpp03/preprocessed/mem_fun_ptr_gen_20.hpp
@@ -417,7 +417,7 @@
                   , A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , A8 , A9 , A10 , A11 , A12 , A13 , A14 , A15 , A16 , A17 , A18
                 >::make(obj, ptr, a0 , a1 , a2 , a3 , a4 , a5 , a6 , a7 , a8 , a9 , a10 , a11 , a12 , a13 , a14 , a15 , a16 , a17 , a18);
             }
-            Object const& obj;
+            Object obj;
             MemPtr ptr;
         };
         struct make_mem_fun_ptr_gen

--- a/include/boost/phoenix/operator/detail/cpp03/preprocessed/mem_fun_ptr_gen_30.hpp
+++ b/include/boost/phoenix/operator/detail/cpp03/preprocessed/mem_fun_ptr_gen_30.hpp
@@ -627,7 +627,7 @@
                   , A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , A8 , A9 , A10 , A11 , A12 , A13 , A14 , A15 , A16 , A17 , A18 , A19 , A20 , A21 , A22 , A23 , A24 , A25 , A26 , A27 , A28
                 >::make(obj, ptr, a0 , a1 , a2 , a3 , a4 , a5 , a6 , a7 , a8 , a9 , a10 , a11 , a12 , a13 , a14 , a15 , a16 , a17 , a18 , a19 , a20 , a21 , a22 , a23 , a24 , a25 , a26 , a27 , a28);
             }
-            Object const& obj;
+            Object obj;
             MemPtr ptr;
         };
         struct make_mem_fun_ptr_gen

--- a/include/boost/phoenix/operator/detail/cpp03/preprocessed/mem_fun_ptr_gen_40.hpp
+++ b/include/boost/phoenix/operator/detail/cpp03/preprocessed/mem_fun_ptr_gen_40.hpp
@@ -837,7 +837,7 @@
                   , A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , A8 , A9 , A10 , A11 , A12 , A13 , A14 , A15 , A16 , A17 , A18 , A19 , A20 , A21 , A22 , A23 , A24 , A25 , A26 , A27 , A28 , A29 , A30 , A31 , A32 , A33 , A34 , A35 , A36 , A37 , A38
                 >::make(obj, ptr, a0 , a1 , a2 , a3 , a4 , a5 , a6 , a7 , a8 , a9 , a10 , a11 , a12 , a13 , a14 , a15 , a16 , a17 , a18 , a19 , a20 , a21 , a22 , a23 , a24 , a25 , a26 , a27 , a28 , a29 , a30 , a31 , a32 , a33 , a34 , a35 , a36 , a37 , a38);
             }
-            Object const& obj;
+            Object obj;
             MemPtr ptr;
         };
         struct make_mem_fun_ptr_gen

--- a/include/boost/phoenix/operator/detail/cpp03/preprocessed/mem_fun_ptr_gen_50.hpp
+++ b/include/boost/phoenix/operator/detail/cpp03/preprocessed/mem_fun_ptr_gen_50.hpp
@@ -1047,7 +1047,7 @@
                   , A0 , A1 , A2 , A3 , A4 , A5 , A6 , A7 , A8 , A9 , A10 , A11 , A12 , A13 , A14 , A15 , A16 , A17 , A18 , A19 , A20 , A21 , A22 , A23 , A24 , A25 , A26 , A27 , A28 , A29 , A30 , A31 , A32 , A33 , A34 , A35 , A36 , A37 , A38 , A39 , A40 , A41 , A42 , A43 , A44 , A45 , A46 , A47 , A48
                 >::make(obj, ptr, a0 , a1 , a2 , a3 , a4 , a5 , a6 , a7 , a8 , a9 , a10 , a11 , a12 , a13 , a14 , a15 , a16 , a17 , a18 , a19 , a20 , a21 , a22 , a23 , a24 , a25 , a26 , a27 , a28 , a29 , a30 , a31 , a32 , a33 , a34 , a35 , a36 , a37 , a38 , a39 , a40 , a41 , a42 , a43 , a44 , a45 , a46 , a47 , a48);
             }
-            Object const& obj;
+            Object obj;
             MemPtr ptr;
         };
         struct make_mem_fun_ptr_gen


### PR DESCRIPTION
Fixes hard to avoid use-after-scope bugs (tests already have them, fixes #73).
Storing ptr actor also strips one level of indirection and is an optimization.

Also had to do some CI maintenance work, added sanitized jobs and ccache.