### PR TITLE
Alternative fix for 5824 ticket

### DIFF
--- a/include/boost/phoenix/core.hpp
+++ b/include/boost/phoenix/core.hpp
@@ -17,7 +17,6 @@
 #include <boost/phoenix/core/nothing.hpp>
 #include <boost/phoenix/core/function_equal.hpp>
 #include <boost/phoenix/core/v2_eval.hpp>
-#include <boost/phoenix/scope/local_variable.hpp> // to fix 5824
 #include <boost/proto/generate.hpp> // attempt to fix problems in intel 14.0.1
 
 #endif

--- a/include/boost/phoenix/operator.hpp
+++ b/include/boost/phoenix/operator.hpp
@@ -18,6 +18,6 @@
 #include <boost/phoenix/operator/logical.hpp>
 #include <boost/phoenix/operator/io.hpp>
 #include <boost/phoenix/operator/member.hpp>
-#include <boost/phoenix/scope/local_variable.hpp> // to fix 5824
+#include <boost/phoenix/statement/sequence.hpp> // to fix 5824
 
 #endif


### PR DESCRIPTION
Just put `statement/sequence.hpp` into `operator.hpp`, because `operator,` is logically expected in operators include, while `scope/local_variable.hpp` does not make any sense (includes `statement/sequence.hpp` by the luck).