### PR TITLE
actor: Remove copy assignment operator

### DIFF
--- a/include/boost/phoenix/core/actor.hpp
+++ b/include/boost/phoenix/core/actor.hpp
@@ -145,7 +145,7 @@ namespace boost { namespace phoenix
 
         BOOST_PROTO_BASIC_EXTENDS(expr_type, actor<Expr>, phoenix_domain)
         BOOST_PROTO_EXTENDS_SUBSCRIPT()
-        BOOST_PROTO_EXTENDS_ASSIGN()
+        BOOST_PROTO_EXTENDS_ASSIGN_()
 
         template <typename Sig>
         struct result;
@@ -224,6 +224,8 @@ namespace boost { namespace phoenix
             return phoenix::eval(*this, phoenix::context(env, default_actions()));
         }
 #endif
+
+        BOOST_DELETED_FUNCTION(actor& operator=(actor const&))
     };
 }}
 


### PR DESCRIPTION
In #64 when I made actor utilize Proto generated assignment operators, I missed that Phoenix copy assignment operator was not producing a lazy expression, instead it simply copied the state over. I do not know why that was done in the first place, the previous behavior is not logical to me, and the current one is more justified, however after thinking thoroughly there is not a lot of use cases for it, the only I had come with is:

```cpp
#include <boost/phoenix.hpp>
#include <iostream>

int main()
{
  using namespace boost::phoenix;

  int i = 0, j = 123;
  auto ri = ref(i);
  (ri = ref(j))();
  std::cout << "i=" << i << ", j=" << j << "\n";
}
```

Since the behavior was broken 6 releases (2.5 years) ago, what is enough time to some one to spot the change and report a regression, but we have not received any, and the new behavior has a little value, I think it is better to simply remove the copy assignment operator, because it will allow us to solve naturally the issue with the `-Wdeprecated-copy` warning (otherwise we need either to define copy constructor and it will break code that relies on `actor` being an aggregate, or suppress the warning what currently impossible on GCC).

Closes #83
Closes #97