### PR TITLE
Partial Revert "std::tuple support (Resolving #103) (#104)"

### DIFF
--- a/include/boost/phoenix/stl/tuple.hpp
+++ b/include/boost/phoenix/stl/tuple.hpp
@@ -110,7 +110,7 @@ namespace boost { namespace phoenix {
     namespace placeholders {
         #define BOOST_PP_LOCAL_LIMITS (1, BOOST_PHOENIX_ARG_LIMIT)
         #define BOOST_PP_LOCAL_MACRO(N)                                                \
-            auto uarg##N =                                                             \
+            const auto uarg##N =                                                       \
             boost::phoenix::get_<(N)-1>(boost::phoenix::placeholders::arg1);
         #include BOOST_PP_LOCAL_ITERATE()
     }


### PR DESCRIPTION
This partial reverts commit 8b6a9c26c115bc2cefea300b5c0abf7edf6dd9b7.

The being-reverted-change put uarg{1..10} in all translation unit that include "boost/phoenix/stl.hpp", should that file is being included by multiple translation unit, each of those translation units will have one definition of each of uarg{1..10}. Thus, we'll run into below error:

> multiple definition of `boost::phoenix::placeholders::uarg1'

Partial Revert the change in question by removing
"boost/phoenix/stl/tuple.hpp" from "boost/phoenix/stl.hpp".

Fix #111 