### PR TITLE
fix warning of deprecated header

### DIFF
--- a/test/Jamfile
+++ b/test/Jamfile
@@ -270,7 +270,7 @@ test-suite phoenix_include :
     [ run include/core/actor.cpp ]
     [ run include/core/argument.cpp ]
     [ run include/core/arity.cpp ]
-    [ run include/core/debug.cpp ]
+    [ run include/debug.cpp ]
     [ run include/core/domain.cpp ]
     [ run include/core/environment.cpp ]
     [ run include/core/expression.cpp ]

--- a/test/include/debug.cpp
+++ b/test/include/debug.cpp
@@ -7,7 +7,7 @@
     file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 ==============================================================================*/
 
-#include <boost/phoenix/core/debug.hpp>
+#include <boost/phoenix/debug.hpp>
 
 int main() {}
 


### PR DESCRIPTION
We forgot to change test include path in
commit 8b4cb05a4da41a819c8709ffef3846b7f4db0f2a ("Move debug.hpp out of core")

Also move debug.cpp out of core

Signed-off-by: Liu Zixian <liuzixian4@huawei.com>