### PR TITLE
Avoid boost::phoenix::placeholders::uarg1..10 ODR violations

### DIFF
--- a/include/boost/phoenix/stl/tuple.hpp
+++ b/include/boost/phoenix/stl/tuple.hpp
@@ -110,7 +110,7 @@ namespace boost { namespace phoenix {
     namespace placeholders {
         #define BOOST_PP_LOCAL_LIMITS (1, BOOST_PHOENIX_ARG_LIMIT)
         #define BOOST_PP_LOCAL_MACRO(N)                                                \
-            auto uarg##N =                                                             \
+            auto const uarg##N =                                                       \
             boost::phoenix::get_<(N)-1>(boost::phoenix::placeholders::arg1);
         #include BOOST_PP_LOCAL_ITERATE()
     }


### PR DESCRIPTION
Those variables, defined in an include file, had external linkage, causing ODR violations.  Make them const to implicitly give them internal linkage.