### PR TITLE
fix link errors in stl/tuple.hpp for C++17 and above

### DIFF
--- a/include/boost/phoenix/stl/tuple.hpp
+++ b/include/boost/phoenix/stl/tuple.hpp
@@ -108,11 +108,20 @@ namespace boost { namespace phoenix {
 
     // Make unpacked argument placeholders
     namespace placeholders {
+
+#if __cplusplus >= 201703L)
         #define BOOST_PP_LOCAL_LIMITS (1, BOOST_PHOENIX_ARG_LIMIT)
         #define BOOST_PP_LOCAL_MACRO(N)                                                \
-            auto uarg##N =                                                             \
+            inline auto uarg##N =                                                      \
             boost::phoenix::get_<(N)-1>(boost::phoenix::placeholders::arg1);
         #include BOOST_PP_LOCAL_ITERATE()
+#else // C++17
+        #define BOOST_PP_LOCAL_LIMITS (1, BOOST_PHOENIX_ARG_LIMIT)
+        #define BOOST_PP_LOCAL_MACRO(N)                                                \
+            auto uarg##N =                                                      \
+            boost::phoenix::get_<(N)-1>(boost::phoenix::placeholders::arg1);
+        #include BOOST_PP_LOCAL_ITERATE()
+#endif // C++17		
     }
 }} // namespace boost::phoenix
 

--- a/include/boost/phoenix/stl/tuple.hpp
+++ b/include/boost/phoenix/stl/tuple.hpp
@@ -109,7 +109,7 @@ namespace boost { namespace phoenix {
     // Make unpacked argument placeholders
     namespace placeholders {
 
-#if __cplusplus >= 201703L)
+#if __cplusplus >= 201703L
         #define BOOST_PP_LOCAL_LIMITS (1, BOOST_PHOENIX_ARG_LIMIT)
         #define BOOST_PP_LOCAL_MACRO(N)                                                \
             inline auto uarg##N =                                                      \


### PR DESCRIPTION
The new variables "uarg..." in stl/tuple.hpp lead to linker warnings, when included in more than one cpp-file. Here is a fix using inline variables for C++17 and above. C++14 is not fixed yet!