### PR TITLE
Add support for modular build structure.

### DIFF
--- a/build.jam
+++ b/build.jam
@@ -1,4 +1,4 @@
-# Copyright René Ferdinand Rivera Morell 2023
+# Copyright René Ferdinand Rivera Morell 2023-2024
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)

--- a/build.jam
+++ b/build.jam
@@ -7,20 +7,20 @@ import project ;
 
 project /boost/phoenix
     : common-requirements
-        <source>/boost/assert//boost_assert
-        <source>/boost/bind//boost_bind
-        <source>/boost/config//boost_config
-        <source>/boost/core//boost_core
-        <source>/boost/function//boost_function
-        <source>/boost/fusion//boost_fusion
-        <source>/boost/mpl//boost_mpl
-        <source>/boost/predef//boost_predef
-        <source>/boost/preprocessor//boost_preprocessor
-        <source>/boost/proto//boost_proto
-        <source>/boost/range//boost_range
-        <source>/boost/smart_ptr//boost_smart_ptr
-        <source>/boost/type_traits//boost_type_traits
-        <source>/boost/utility//boost_utility
+        <library>/boost/assert//boost_assert
+        <library>/boost/bind//boost_bind
+        <library>/boost/config//boost_config
+        <library>/boost/core//boost_core
+        <library>/boost/function//boost_function
+        <library>/boost/fusion//boost_fusion
+        <library>/boost/mpl//boost_mpl
+        <library>/boost/predef//boost_predef
+        <library>/boost/preprocessor//boost_preprocessor
+        <library>/boost/proto//boost_proto
+        <library>/boost/range//boost_range
+        <library>/boost/smart_ptr//boost_smart_ptr
+        <library>/boost/type_traits//boost_type_traits
+        <library>/boost/utility//boost_utility
         <include>include
     ;
 

--- a/build.jam
+++ b/build.jam
@@ -5,29 +5,32 @@
 
 require-b2 5.2 ;
 
+constant boost_dependencies :
+    /boost/assert//boost_assert
+    /boost/bind//boost_bind
+    /boost/config//boost_config
+    /boost/core//boost_core
+    /boost/function//boost_function
+    /boost/fusion//boost_fusion
+    /boost/mpl//boost_mpl
+    /boost/predef//boost_predef
+    /boost/preprocessor//boost_preprocessor
+    /boost/proto//boost_proto
+    /boost/range//boost_range
+    /boost/smart_ptr//boost_smart_ptr
+    /boost/type_traits//boost_type_traits
+    /boost/utility//boost_utility ;
+
 project /boost/phoenix
     : common-requirements
-        <library>/boost/assert//boost_assert
-        <library>/boost/bind//boost_bind
-        <library>/boost/config//boost_config
-        <library>/boost/core//boost_core
-        <library>/boost/function//boost_function
-        <library>/boost/fusion//boost_fusion
-        <library>/boost/mpl//boost_mpl
-        <library>/boost/predef//boost_predef
-        <library>/boost/preprocessor//boost_preprocessor
-        <library>/boost/proto//boost_proto
-        <library>/boost/range//boost_range
-        <library>/boost/smart_ptr//boost_smart_ptr
-        <library>/boost/type_traits//boost_type_traits
-        <library>/boost/utility//boost_utility
         <include>include
     ;
 
 explicit
-    [ alias boost_phoenix ]
+    [ alias boost_phoenix : : : : <library>$(boost_dependencies) ]
     [ alias all : boost_phoenix test ]
     ;
 
 call-if : boost-library phoenix
     ;
+

--- a/build.jam
+++ b/build.jam
@@ -1,0 +1,33 @@
+# Copyright René Ferdinand Rivera Morell 2023
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+import project ;
+
+project /boost/phoenix
+    : common-requirements
+        <source>/boost/assert//boost_assert
+        <source>/boost/bind//boost_bind
+        <source>/boost/config//boost_config
+        <source>/boost/core//boost_core
+        <source>/boost/function//boost_function
+        <source>/boost/fusion//boost_fusion
+        <source>/boost/mpl//boost_mpl
+        <source>/boost/predef//boost_predef
+        <source>/boost/preprocessor//boost_preprocessor
+        <source>/boost/proto//boost_proto
+        <source>/boost/range//boost_range
+        <source>/boost/smart_ptr//boost_smart_ptr
+        <source>/boost/type_traits//boost_type_traits
+        <source>/boost/utility//boost_utility
+        <include>include
+    ;
+
+explicit
+    [ alias boost_phoenix ]
+    [ alias all : boost_phoenix test ]
+    ;
+
+call-if : boost-library phoenix
+    ;

--- a/build.jam
+++ b/build.jam
@@ -3,6 +3,8 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
+require-b2 5.1 ;
+
 import project ;
 
 project /boost/phoenix

--- a/build.jam
+++ b/build.jam
@@ -3,9 +3,7 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-require-b2 5.1 ;
-
-import project ;
+require-b2 5.2 ;
 
 project /boost/phoenix
     : common-requirements

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -11,6 +11,7 @@
 import testing ;
 import os ;
 
+import-search /boost/config/checks ;
 import config : requires ;
 
 if [ os.environ CI ]
@@ -88,7 +89,7 @@ test-suite phoenix_bind :
     [ run bind/bind_member_variable_tests.cpp ]
     [ run bind/bug5782.cpp ]
     ;
-    
+
 test-suite phoenix_statement :
     [ run statement/if_tests.cpp ]
     [ run statement/loops_tests.cpp ]
@@ -96,20 +97,20 @@ test-suite phoenix_statement :
     [ run statement/exceptions.cpp ]
     [ run statement/bug5715.cpp ]
     ;
-        
+
 test-suite phoenix_container :
-    [ run container/container_tests1a.cpp ] 
-    [ run container/container_tests1b.cpp ] 
-    [ run container/container_tests2a.cpp ] 
-    [ run container/container_tests2b.cpp ] 
-    [ run container/container_tests3a.cpp ] 
-    [ run container/container_tests3b.cpp ] 
-    [ run container/container_tests4a.cpp ] 
-    [ run container/container_tests4b.cpp ] 
-    [ run container/container_tests5a.cpp ] 
-    [ run container/container_tests5b.cpp ] 
-    [ run container/container_tests6a.cpp ] 
-    [ run container/container_tests6b.cpp ] 
+    [ run container/container_tests1a.cpp ]
+    [ run container/container_tests1b.cpp ]
+    [ run container/container_tests2a.cpp ]
+    [ run container/container_tests2b.cpp ]
+    [ run container/container_tests3a.cpp ]
+    [ run container/container_tests3b.cpp ]
+    [ run container/container_tests4a.cpp ]
+    [ run container/container_tests4b.cpp ]
+    [ run container/container_tests5a.cpp ]
+    [ run container/container_tests5b.cpp ]
+    [ run container/container_tests6a.cpp ]
+    [ run container/container_tests6b.cpp ]
     [ run container/container_tests7a.cpp ]
     [ run container/container_tests7b.cpp ]
     [ run container/container_tests8a.cpp ]

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -11,7 +11,7 @@
 import testing ;
 import os ;
 
-import ../../config/checks/config : requires ;
+import config : requires ;
 
 if [ os.environ CI ]
 {
@@ -29,11 +29,11 @@ project
         $(CI_DEFINES)
     ;
 
-local multi-threading = <library>/boost/thread
+local multi-threading = <library>/boost/thread//boost_thread
                         <threading>multi <define>BOOST_ALL_NO_LIB=1 ;
 
 test-suite phoenix_core :
-    [ run core/custom_terminal.cpp ]
+    [ run core/custom_terminal.cpp /boost/log//boost_log ]
     [ run core/intel_test.cpp ]
     [ run core/primitives_tests.cpp ]
     ;
@@ -176,10 +176,10 @@ test-suite phoenix_algorithm :
     [ run algorithm/transformation2.cpp ]
     [ run algorithm/transformation3.cpp ]
     [ run algorithm/transformation4.cpp ]
-    [ run algorithm/querying.cpp ]
-    [ run algorithm/querying_find.cpp ]
+    [ run algorithm/querying.cpp /boost/assign//boost_assign ]
+    [ run algorithm/querying_find.cpp /boost/assign//boost_assign ]
     [ run algorithm/querying2.cpp ]
-    [ run algorithm/querying_find2.cpp ]
+    [ run algorithm/querying_find2.cpp /boost/assign//boost_assign ]
     ;
 
 test-suite phoenix_boost_bind_compatibility :
@@ -217,7 +217,7 @@ test-suite phoenix_boost_bind_compatibility :
 
 test-suite phoenix_bll_compatibility :
     [ run bll_compatibility/algorithm_test.cpp ]
-    [ run bll_compatibility/bind_tests_advanced.cpp ]
+    [ run bll_compatibility/bind_tests_advanced.cpp /boost/any//boost_any ]
 #    [ run bll_compatibility/bind_tests_simple.cpp ]
 #    [ run bll_compatibility/bind_tests_simple_f_refs.cpp ]
 #    [ run bll_compatibility/bll_and_function.cpp ]
@@ -242,7 +242,7 @@ test-suite phoenix_regression :
     [ run regression/bug5626.cpp ]
     [ run regression/bug5824.cpp ]
  #   [ run regression/bug5875.cpp ]
-    [ run regression/bug5968.cpp ]
+    [ run regression/bug5968.cpp /boost/signals2//boost_signals2 ]
     [ run regression/bug6040.cpp ]
     [ run regression/bug6268.cpp ]
     [ run regression/bug7165.cpp ]

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -23,6 +23,7 @@ if [ os.environ CI ]
 
 project
     : requirements
+        <library>/boost/phoenix//boost_phoenix
         <toolset>msvc:<define>_SCL_SECURE_NO_DEPRECATE
         <toolset>msvc:<define>_SCL_SECURE_NO_WARNINGS
         <toolset>msvc:<define>_CRT_SECURE_NO_DEPRECATE


### PR DESCRIPTION
This is part of the effort to make the Boost libraries "modular" for build and consumption. See https://lists.boost.org/Archives/boost/2024/01/255704.php and https://github.com/grafikrobot/boost-b2-modular/blob/b2-modular/README.adoc for more information.

This PR depends on the following other PRs being merged to both develop and master branches of the respective repos:

- https://github.com/boostorg/boost/pull/854

This PR will be changed to ready for review, i.e. not draft, when the above are merged. Do not merge this one until that time.