### PR TITLE
Fix subscript-expression to comply with C++23 comma separator rules

### DIFF
--- a/test/bll_compatibility/algorithm_test.cpp
+++ b/test/bll_compatibility/algorithm_test.cpp
@@ -51,7 +51,7 @@ void test_foreach() {
   // var replaced with ref, protect(..) replaced with lambda[..], no need for bind
   // phoenix algorithms are range based
   std::for_each(a, a + 10,
-          phoenix::for_each(_1, lambda[_1 = ref(sum), ++ref(sum)]));
+          phoenix::for_each(_1, lambda[(_1 = ref(sum), ++ref(sum))]));
                 /*phoenix::bind(phoenix::for_each, _1,
                             lambda[_1 = ref(sum), ++ref(sum)]));*/
 

--- a/test/statement/exceptions.cpp
+++ b/test/statement/exceptions.cpp
@@ -121,11 +121,11 @@ int main()
         try_
         [ throw_(runtime_error("error")) ]
         .catch_<exception>(_e)
-        [
+        [(
             ref(caught_exception) = true
             // ambiguous with std::ref
           , phx::ref(what) = phx::bind(&exception::what, _e)
-        ]();
+        )]();
 
         BOOST_TEST(caught_exception);
         BOOST_TEST(what == string("error"));
@@ -138,11 +138,11 @@ int main()
         try_
         [ throw_(extended_exception("error")) ]
         .catch_<base_exception>(_e) // A thrown object should not be copied due to slicing.
-        [
+        [(
             ref(caught_exception) = true
             // ambiguous with std::ref
           , phx::ref(what) = phx::bind(&exception::what, _e)
-        ]();
+        )]();
 
         BOOST_TEST(caught_exception);
         BOOST_TEST(what == string("error"));
@@ -167,11 +167,11 @@ int main()
         .catch_<string>()
             [ ref(caught_correct_exception) = false ]
         .catch_<exception>(_e)
-        [
+        [(
             ref(caught_correct_exception) = true
             // ambiguous with std::ref
           , phx::ref(what) = phx::bind(&exception::what, _e)
-        ]();
+        )]();
 
         BOOST_TEST(caught_correct_exception);
         BOOST_TEST(what == string("error"));

--- a/test/statement/if_tests.cpp
+++ b/test/statement/if_tests.cpp
@@ -27,10 +27,10 @@ main()
 
     for_each(v.begin(), v.end(),
         if_(arg1 > 3 && arg1 <= 8)
-        [
+        [(
             std::cout << arg1 << ", ",
             ref(x) += arg1
-        ]
+        )]
     );
 
     std::cout << std::endl;
@@ -49,15 +49,15 @@ main()
         .else_
         [
             if_(arg1 == 5)
-            [
+            [(
                 std::cout << arg1 << " == 5\n",
                 ref(z) += arg1
-            ]
+            )]
             .else_
-            [
+            [(
                 std::cout << arg1 << " < 5\n",
                 ref(y) += arg1
-            ]
+            )]
         ]
     );
 

--- a/test/statement/loops_tests.cpp
+++ b/test/statement/loops_tests.cpp
@@ -34,10 +34,10 @@ main()
     for_each(v.begin(), v.end(),
         (
             while_(arg1--)
-            [
+            [(
                 cout << arg1 << ", ",
                 ++ref(x)
-            ],
+            )],
             cout << val("\n")
         )
     );
@@ -50,10 +50,10 @@ main()
     for_each(v.begin(), v.end(),
         (
             do_
-            [
+            [(
                 cout << arg1 << ", ",
                 ++ref(x)
-            ]
+            )]
             .while_(arg1--),
             cout << val("\n")
         )
@@ -68,10 +68,10 @@ main()
     for_each(v.begin(), v.end(),
         (
             for_(ref(iii) = 0, ref(iii) < arg1, ++ref(iii))
-            [
+            [(
                 cout << arg1 << ", ",
                 ++ref(x)
-            ],
+            )],
             cout << val("\n")
         )
     );

--- a/test/statement/switch_tests.cpp
+++ b/test/statement/switch_tests.cpp
@@ -51,25 +51,25 @@ main()
     
     for_each(v.begin(), v.end(),
         switch_(_1)
-        [
+        [(
             case_<1>(cout << val("<1>") << endl),
             case_<2>(cout << val("<2>") << endl),
             case_<3>(cout << val("<3>") << endl),
             case_<4>(cout << val("<4>") << endl)
-        ]
+        )]
     );
 
     cout << endl;
 
     for_each(v.begin(), v.end(),
         switch_(_1)
-        [
+        [(
             case_<1>(cout << val("<1>") << endl),
             case_<2>(cout << val("<2>") << endl),
             case_<3>(cout << val("<3>") << endl),
             case_<4>(cout << val("<4>") << endl),
             default_(cout << val("<over 4>") << endl)
-        ]
+        )]
     );
 
     return boost::report_errors();


### PR DESCRIPTION
Creating this PR in response to https://github.com/boostorg/phoenix/issues/123

In C++23, the grammar for subscript-expressions was updated to accept an expression-list, which causes the top-level comma (,) to be treated as a separator rather than part of a single expression. This leads to parsing issues when using comma expressions directly inside subscript operators.

To address this, affected expressions have been wrapped in parentheses to ensure the intended evaluation order is preserved and to maintain compatibility with C++23 and beyond.

Example fix:
```c++
// Before (invalid in C++23):
while_(arg1--)
[
    cout << arg1 << ", ",
    ++ref(x)
]

// After (valid in C++23):
while_(arg1--)
[
    (cout << arg1 << ", ", ++ref(x))
]
```