### PR TITLE
Remove dependencies on Boost.StaticAssert

### DIFF
--- a/.drone/boost.sh
+++ b/.drone/boost.sh
@@ -78,7 +78,6 @@ git submodule init libs/serialization
 git submodule init libs/signals2
 git submodule init libs/smart_ptr
 git submodule init libs/spirit
-git submodule init libs/static_assert
 git submodule init libs/system
 git submodule init libs/thread
 git submodule init libs/throw_exception

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -699,7 +699,6 @@ jobs:
           git submodule init libs/signals2
           git submodule init libs/smart_ptr
           git submodule init libs/spirit
-          git submodule init libs/static_assert
           git submodule init libs/system
           git submodule init libs/thread
           git submodule init libs/throw_exception
@@ -878,7 +877,6 @@ jobs:
           git submodule init libs/signals2
           git submodule init libs/smart_ptr
           git submodule init libs/spirit
-          git submodule init libs/static_assert
           git submodule init libs/system
           git submodule init libs/thread
           git submodule init libs/throw_exception

--- a/.travis.yml
+++ b/.travis.yml
@@ -505,7 +505,6 @@ install:
   - git submodule init libs/signals2
   - git submodule init libs/smart_ptr
   - git submodule init libs/spirit
-  - git submodule init libs/static_assert
   - git submodule init libs/system
   - git submodule init libs/thread
   - git submodule init libs/throw_exception

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -112,7 +112,6 @@ install:
   - git submodule init libs/signals2
   - git submodule init libs/smart_ptr
   - git submodule init libs/spirit
-  - git submodule init libs/static_assert
   - git submodule init libs/system
   - git submodule init libs/thread
   - git submodule init libs/throw_exception


### PR DESCRIPTION
Boost.StaticAssert has been merged into Boost.Config, so remove the dependency.